### PR TITLE
Fix htmlspecialchars null deprecation warning in admin member views

### DIFF
--- a/views/admin/edit_member.php
+++ b/views/admin/edit_member.php
@@ -3,35 +3,35 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header">
-                    <h4><?= htmlspecialchars($title) ?></h4>
+                    <h4><?= htmlspecialchars($title ?? '') ?></h4>
                 </div>
                 <div class="card-body">
                     <?php if (!empty($error)): ?>
-                        <div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+                        <div class="alert alert-danger"><?= htmlspecialchars($error ?? '') ?></div>
                     <?php endif; ?>
-                    
+
                     <?php if (!empty($success)): ?>
-                        <div class="alert alert-success"><?= htmlspecialchars($success) ?></div>
+                        <div class="alert alert-success"><?= htmlspecialchars($success ?? '') ?></div>
                     <?php endif; ?>
                     
                     <form method="POST">
                         <?php if (!empty($csrf) && is_array($csrf)): ?>
                             <?php foreach ($csrf as $name => $value): ?>
-                                <input type="hidden" name="<?= htmlspecialchars($name) ?>" value="<?= htmlspecialchars($value) ?>">
+                                <input type="hidden" name="<?= htmlspecialchars($name ?? '') ?>" value="<?= htmlspecialchars($value ?? '') ?>">
                             <?php endforeach; ?>
                         <?php endif; ?>
                         
                         <div class="mb-3">
                             <label for="username" class="form-label">Username</label>
-                            <input type="text" class="form-control" id="username" name="username" 
-                                   value="<?= htmlspecialchars($editMember->username) ?>" required
-                                   <?= $editMember->username === 'public-user-entity' ? 'readonly' : '' ?>>
+                            <input type="text" class="form-control" id="username" name="username"
+                                   value="<?= htmlspecialchars($editMember->username ?? '') ?>" required
+                                   <?= ($editMember->username ?? '') === 'public-user-entity' ? 'readonly' : '' ?>>
                         </div>
-                        
+
                         <div class="mb-3">
                             <label for="email" class="form-label">Email</label>
-                            <input type="email" class="form-control" id="email" name="email" 
-                                   value="<?= htmlspecialchars($editMember->email) ?>" required>
+                            <input type="email" class="form-control" id="email" name="email"
+                                   value="<?= htmlspecialchars($editMember->email ?? '') ?>" required>
                         </div>
                         
                         <div class="mb-3">
@@ -43,14 +43,14 @@
                         <div class="mb-3">
                             <label for="level" class="form-label">User Level</label>
                             <select class="form-select" id="level" name="level" required
-                                    <?= $editMember->username === 'public-user-entity' ? 'disabled' : '' ?>>
-                                <option value="0" <?= $editMember->level == 0 ? 'selected' : '' ?>>ROOT (0)</option>
-                                <option value="1" <?= $editMember->level == 1 ? 'selected' : '' ?>>ROOT (1)</option>
-                                <option value="50" <?= $editMember->level == 50 ? 'selected' : '' ?>>ADMIN (50)</option>
-                                <option value="100" <?= $editMember->level == 100 ? 'selected' : '' ?>>MEMBER (100)</option>
-                                <option value="101" <?= $editMember->level == 101 ? 'selected' : '' ?>>PUBLIC (101)</option>
+                                    <?= ($editMember->username ?? '') === 'public-user-entity' ? 'disabled' : '' ?>>
+                                <option value="0" <?= ($editMember->level ?? 100) == 0 ? 'selected' : '' ?>>ROOT (0)</option>
+                                <option value="1" <?= ($editMember->level ?? 100) == 1 ? 'selected' : '' ?>>ROOT (1)</option>
+                                <option value="50" <?= ($editMember->level ?? 100) == 50 ? 'selected' : '' ?>>ADMIN (50)</option>
+                                <option value="100" <?= ($editMember->level ?? 100) == 100 ? 'selected' : '' ?>>MEMBER (100)</option>
+                                <option value="101" <?= ($editMember->level ?? 100) == 101 ? 'selected' : '' ?>>PUBLIC (101)</option>
                             </select>
-                            <?php if ($editMember->username === 'public-user-entity'): ?>
+                            <?php if (($editMember->username ?? '') === 'public-user-entity'): ?>
                                 <input type="hidden" name="level" value="101">
                             <?php endif; ?>
                         </div>
@@ -58,12 +58,12 @@
                         <div class="mb-3">
                             <label for="status" class="form-label">Status</label>
                             <select class="form-select" id="status" name="status" required
-                                    <?= $editMember->username === 'public-user-entity' ? 'disabled' : '' ?>>
-                                <option value="active" <?= $editMember->status === 'active' ? 'selected' : '' ?>>Active</option>
-                                <option value="suspended" <?= $editMember->status === 'suspended' ? 'selected' : '' ?>>Suspended</option>
-                                <option value="inactive" <?= $editMember->status === 'inactive' ? 'selected' : '' ?>>Inactive</option>
+                                    <?= ($editMember->username ?? '') === 'public-user-entity' ? 'disabled' : '' ?>>
+                                <option value="active" <?= ($editMember->status ?? '') === 'active' ? 'selected' : '' ?>>Active</option>
+                                <option value="suspended" <?= ($editMember->status ?? '') === 'suspended' ? 'selected' : '' ?>>Suspended</option>
+                                <option value="inactive" <?= ($editMember->status ?? '') === 'inactive' ? 'selected' : '' ?>>Inactive</option>
                             </select>
-                            <?php if ($editMember->username === 'public-user-entity'): ?>
+                            <?php if (($editMember->username ?? '') === 'public-user-entity'): ?>
                                 <input type="hidden" name="status" value="active">
                                 <small class="form-text text-muted">System user - status cannot be changed</small>
                             <?php endif; ?>
@@ -72,9 +72,9 @@
                         <div class="mb-3">
                             <label class="form-label">Member Information</label>
                             <p class="form-control-plaintext">
-                                ID: <?= $editMember->id ?><br>
-                                Created: <?= $editMember->created_at ?><br>
-                                Updated: <?= $editMember->updated_at ?>
+                                ID: <?= htmlspecialchars($editMember->id ?? '') ?><br>
+                                Created: <?= htmlspecialchars($editMember->created_at ?? 'N/A') ?><br>
+                                Updated: <?= htmlspecialchars($editMember->updated_at ?? 'N/A') ?>
                             </p>
                         </div>
                         

--- a/views/admin/members.php
+++ b/views/admin/members.php
@@ -7,7 +7,7 @@
     </div>
     
     <?php if (!empty($success)): ?>
-        <div class="alert alert-success"><?= htmlspecialchars($success) ?></div>
+        <div class="alert alert-success"><?= htmlspecialchars($success ?? '') ?></div>
     <?php endif; ?>
     
     <!-- Search and Filter -->
@@ -57,8 +57,8 @@
                 <?php foreach ($members as $member): ?>
                     <tr>
                         <td><?= $member->id ?></td>
-                        <td><?= htmlspecialchars($member->username) ?></td>
-                        <td><?= htmlspecialchars($member->email) ?></td>
+                        <td><?= htmlspecialchars($member->username ?? '') ?></td>
+                        <td><?= htmlspecialchars($member->email ?? '') ?></td>
                         <td>
                             <?php
                             $levelName = 'Unknown';
@@ -107,7 +107,7 @@
                             }
                             ?>
                             <span class="badge bg-<?= $statusClass ?>">
-                                <?= htmlspecialchars($member->status) ?>
+                                <?= htmlspecialchars($member->status ?? '') ?>
                             </span>
                         </td>
                         <td>


### PR DESCRIPTION
## Summary
- Added null coalescing operators (`?? ''`) to all `htmlspecialchars()` calls in `views/admin/members.php` and `views/admin/edit_member.php`
- Prevents PHP 8.1+ deprecation warnings when member properties are null
- Fixes error: "htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated"

## Test plan
- [ ] Navigate to /admin/members and verify no deprecation warnings appear
- [ ] Click "Edit" on any member and verify the edit form loads without errors
- [ ] Submit the edit form and verify it saves successfully
- [ ] Verify member list displays correctly with all columns populated

Fixes: mfrederico/myctobot#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)