### PR TITLE
Fix htmlspecialchars null error in admin member views

### DIFF
--- a/views/admin/add_member.php
+++ b/views/admin/add_member.php
@@ -3,7 +3,7 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header">
-                    <h4><?= htmlspecialchars($title) ?></h4>
+                    <h4><?= htmlspecialchars($title ?? '') ?></h4>
                 </div>
                 <div class="card-body">
                     <?php if (!empty($error)): ?>
@@ -17,7 +17,7 @@
                     <form method="POST">
                         <?php if (!empty($csrf) && is_array($csrf)): ?>
                             <?php foreach ($csrf as $name => $value): ?>
-                                <input type="hidden" name="<?= htmlspecialchars($name) ?>" value="<?= htmlspecialchars($value) ?>">
+                                <input type="hidden" name="<?= htmlspecialchars($name ?? '') ?>" value="<?= htmlspecialchars($value ?? '') ?>">
                             <?php endforeach; ?>
                         <?php endif; ?>
                         

--- a/views/admin/edit_member.php
+++ b/views/admin/edit_member.php
@@ -3,7 +3,7 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header">
-                    <h4><?= htmlspecialchars($title) ?></h4>
+                    <h4><?= htmlspecialchars($title ?? '') ?></h4>
                 </div>
                 <div class="card-body">
                     <?php if (!empty($error)): ?>
@@ -17,21 +17,21 @@
                     <form method="POST">
                         <?php if (!empty($csrf) && is_array($csrf)): ?>
                             <?php foreach ($csrf as $name => $value): ?>
-                                <input type="hidden" name="<?= htmlspecialchars($name) ?>" value="<?= htmlspecialchars($value) ?>">
+                                <input type="hidden" name="<?= htmlspecialchars($name ?? '') ?>" value="<?= htmlspecialchars($value ?? '') ?>">
                             <?php endforeach; ?>
                         <?php endif; ?>
                         
                         <div class="mb-3">
                             <label for="username" class="form-label">Username</label>
-                            <input type="text" class="form-control" id="username" name="username" 
-                                   value="<?= htmlspecialchars($editMember->username) ?>" required
-                                   <?= $editMember->username === 'public-user-entity' ? 'readonly' : '' ?>>
+                            <input type="text" class="form-control" id="username" name="username"
+                                   value="<?= htmlspecialchars($editMember->username ?? '') ?>" required
+                                   <?= ($editMember->username ?? '') === 'public-user-entity' ? 'readonly' : '' ?>>
                         </div>
-                        
+
                         <div class="mb-3">
                             <label for="email" class="form-label">Email</label>
-                            <input type="email" class="form-control" id="email" name="email" 
-                                   value="<?= htmlspecialchars($editMember->email) ?>" required>
+                            <input type="email" class="form-control" id="email" name="email"
+                                   value="<?= htmlspecialchars($editMember->email ?? '') ?>" required>
                         </div>
                         
                         <div class="mb-3">
@@ -43,14 +43,14 @@
                         <div class="mb-3">
                             <label for="level" class="form-label">User Level</label>
                             <select class="form-select" id="level" name="level" required
-                                    <?= $editMember->username === 'public-user-entity' ? 'disabled' : '' ?>>
-                                <option value="0" <?= $editMember->level == 0 ? 'selected' : '' ?>>ROOT (0)</option>
-                                <option value="1" <?= $editMember->level == 1 ? 'selected' : '' ?>>ROOT (1)</option>
-                                <option value="50" <?= $editMember->level == 50 ? 'selected' : '' ?>>ADMIN (50)</option>
-                                <option value="100" <?= $editMember->level == 100 ? 'selected' : '' ?>>MEMBER (100)</option>
-                                <option value="101" <?= $editMember->level == 101 ? 'selected' : '' ?>>PUBLIC (101)</option>
+                                    <?= ($editMember->username ?? '') === 'public-user-entity' ? 'disabled' : '' ?>>
+                                <option value="0" <?= ($editMember->level ?? 100) == 0 ? 'selected' : '' ?>>ROOT (0)</option>
+                                <option value="1" <?= ($editMember->level ?? 100) == 1 ? 'selected' : '' ?>>ROOT (1)</option>
+                                <option value="50" <?= ($editMember->level ?? 100) == 50 ? 'selected' : '' ?>>ADMIN (50)</option>
+                                <option value="100" <?= ($editMember->level ?? 100) == 100 ? 'selected' : '' ?>>MEMBER (100)</option>
+                                <option value="101" <?= ($editMember->level ?? 100) == 101 ? 'selected' : '' ?>>PUBLIC (101)</option>
                             </select>
-                            <?php if ($editMember->username === 'public-user-entity'): ?>
+                            <?php if (($editMember->username ?? '') === 'public-user-entity'): ?>
                                 <input type="hidden" name="level" value="101">
                             <?php endif; ?>
                         </div>
@@ -58,12 +58,12 @@
                         <div class="mb-3">
                             <label for="status" class="form-label">Status</label>
                             <select class="form-select" id="status" name="status" required
-                                    <?= $editMember->username === 'public-user-entity' ? 'disabled' : '' ?>>
-                                <option value="active" <?= $editMember->status === 'active' ? 'selected' : '' ?>>Active</option>
-                                <option value="suspended" <?= $editMember->status === 'suspended' ? 'selected' : '' ?>>Suspended</option>
-                                <option value="inactive" <?= $editMember->status === 'inactive' ? 'selected' : '' ?>>Inactive</option>
+                                    <?= ($editMember->username ?? '') === 'public-user-entity' ? 'disabled' : '' ?>>
+                                <option value="active" <?= ($editMember->status ?? '') === 'active' ? 'selected' : '' ?>>Active</option>
+                                <option value="suspended" <?= ($editMember->status ?? '') === 'suspended' ? 'selected' : '' ?>>Suspended</option>
+                                <option value="inactive" <?= ($editMember->status ?? '') === 'inactive' ? 'selected' : '' ?>>Inactive</option>
                             </select>
-                            <?php if ($editMember->username === 'public-user-entity'): ?>
+                            <?php if (($editMember->username ?? '') === 'public-user-entity'): ?>
                                 <input type="hidden" name="status" value="active">
                                 <small class="form-text text-muted">System user - status cannot be changed</small>
                             <?php endif; ?>
@@ -72,9 +72,9 @@
                         <div class="mb-3">
                             <label class="form-label">Member Information</label>
                             <p class="form-control-plaintext">
-                                ID: <?= $editMember->id ?><br>
-                                Created: <?= $editMember->created_at ?><br>
-                                Updated: <?= $editMember->updated_at ?>
+                                ID: <?= $editMember->id ?? '' ?><br>
+                                Created: <?= htmlspecialchars($editMember->created_at ?? 'N/A') ?><br>
+                                Updated: <?= htmlspecialchars($editMember->updated_at ?? 'N/A') ?>
                             </p>
                         </div>
                         

--- a/views/admin/members.php
+++ b/views/admin/members.php
@@ -57,8 +57,8 @@
                 <?php foreach ($members as $member): ?>
                     <tr>
                         <td><?= $member->id ?></td>
-                        <td><?= htmlspecialchars($member->username) ?></td>
-                        <td><?= htmlspecialchars($member->email) ?></td>
+                        <td><?= htmlspecialchars($member->username ?? '') ?></td>
+                        <td><?= htmlspecialchars($member->email ?? '') ?></td>
                         <td>
                             <?php
                             $levelName = 'Unknown';
@@ -107,7 +107,7 @@
                             }
                             ?>
                             <span class="badge bg-<?= $statusClass ?>">
-                                <?= htmlspecialchars($member->status) ?>
+                                <?= htmlspecialchars($member->status ?? '') ?>
                             </span>
                         </td>
                         <td>


### PR DESCRIPTION
## Summary

Fixes the PHP 8+ deprecation warning: `htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated`

This error occurred when viewing/editing members in the admin panel because database fields could potentially be null.

## Changes

Added null coalescing operator (`?? ''`) to all `htmlspecialchars()` calls in the following files:

- **views/admin/members.php**: Fixed `$member->username`, `$member->email`, and `$member->status`
- **views/admin/edit_member.php**: Fixed `$title`, CSRF token fields, and all `$editMember` properties
- **views/admin/add_member.php**: Fixed `$title` and CSRF token fields

## Test Plan

- [ ] Navigate to Admin > Members page and verify no deprecation warnings appear
- [ ] Edit an existing member and verify the form loads correctly
- [ ] Add a new member and verify the form works correctly
- [ ] Check server logs for any htmlspecialchars deprecation warnings

Fixes: mfrederico/myctobot#4

---
Generated with Claude Code