### PR TITLE
feat: Implement CEO directive message validation and parsing

### DIFF
--- a/controls/Directives.php
+++ b/controls/Directives.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Directives Controller
+ *
+ * Handles incoming CEO directive messages.
+ * Validates directives and queues them for processing.
+ */
+
+namespace app;
+
+use \Flight as Flight;
+use \app\services\CeoDirectiveService;
+
+require_once __DIR__ . '/../services/CeoDirectiveService.php';
+
+class Directives extends BaseControls\Control {
+
+    private CeoDirectiveService $directiveService;
+
+    public function __construct() {
+        parent::__construct();
+        $this->directiveService = new CeoDirectiveService();
+    }
+
+    /**
+     * Receive a CEO directive
+     * Endpoint: POST /directives/receive
+     *
+     * Expected JSON body:
+     * {
+     *   "directive_type": "strategic|operational|urgent|informational|action_required",
+     *   "content": "The directive content...",
+     *   "priority": "critical|high|medium|low",
+     *   "timestamp": "2024-01-15T10:30:00Z",
+     *   "subject": "Optional subject line",
+     *   "metadata": {"key": "value"},
+     *   "expires_at": "2024-01-20T10:30:00Z",
+     *   "source": "ceo@example.com",
+     *   "target_team": "engineering",
+     *   "requires_acknowledgment": true
+     * }
+     */
+    public function receive() {
+        // Only accept POST requests
+        if (Flight::request()->method !== 'POST') {
+            $this->logger->warning('Directives endpoint called with non-POST method', [
+                'method' => Flight::request()->method
+            ]);
+            Flight::response()->status(405);
+            Flight::json([
+                'success' => false,
+                'error' => 'Method not allowed. Use POST.'
+            ]);
+            return;
+        }
+
+        // Get raw payload
+        $payload = file_get_contents('php://input');
+
+        if (empty($payload)) {
+            $this->logger->warning('Directives receive: empty payload');
+            Flight::response()->status(400);
+            Flight::json([
+                'success' => false,
+                'error' => 'Empty request body'
+            ]);
+            return;
+        }
+
+        // Parse JSON
+        $directive = json_decode($payload, true);
+        if ($directive === null && json_last_error() !== JSON_ERROR_NONE) {
+            $this->logger->warning('Directives receive: invalid JSON', [
+                'json_error' => json_last_error_msg()
+            ]);
+            Flight::response()->status(400);
+            Flight::json([
+                'success' => false,
+                'error' => 'Invalid JSON: ' . json_last_error_msg()
+            ]);
+            return;
+        }
+
+        // Validate the directive
+        $validation = $this->directiveService->validate($directive);
+
+        if (!$validation['valid']) {
+            $this->logger->info('Directive validation failed', [
+                'error_count' => count($validation['errors'])
+            ]);
+
+            // Determine specific error type for status code
+            $hasMissingFields = false;
+            $hasTypeMismatch = false;
+
+            foreach ($validation['errors'] as $error) {
+                if ($error['error'] === 'missing_field' || $error['error'] === 'empty_field') {
+                    $hasMissingFields = true;
+                }
+                if ($error['error'] === 'type_mismatch') {
+                    $hasTypeMismatch = true;
+                }
+            }
+
+            // Use 400 for validation errors
+            Flight::response()->status(400);
+            Flight::json([
+                'success' => false,
+                'error' => 'Validation failed',
+                'validation_errors' => $validation['errors'],
+                'warnings' => $validation['warnings'],
+                'error_summary' => $this->buildErrorSummary($validation['errors'])
+            ]);
+            return;
+        }
+
+        // Get member ID if authenticated (optional - directives can come from external sources)
+        $memberId = null;
+        if (Flight::isLoggedIn()) {
+            $memberId = $this->member->id ?? null;
+        }
+
+        // Parse and queue the directive
+        $result = $this->directiveService->parseAndQueue($directive, $memberId);
+
+        if (!$result['success']) {
+            $this->logger->error('Failed to queue directive', [
+                'error' => $result['error']
+            ]);
+            Flight::response()->status(500);
+            Flight::json([
+                'success' => false,
+                'error' => $result['error'],
+                'validation_errors' => $result['validation_errors'] ?? []
+            ]);
+            return;
+        }
+
+        // Success - directive queued
+        $this->logger->info('Directive received and queued', [
+            'directive_id' => $result['directive_id'],
+            'directive_type' => $directive['directive_type'],
+            'priority' => $directive['priority']
+        ]);
+
+        Flight::response()->status(201);
+        Flight::json([
+            'success' => true,
+            'message' => 'Directive received and queued for processing',
+            'directive_id' => $result['directive_id'],
+            'status' => $result['status'],
+            'warnings' => $result['warnings'] ?? []
+        ]);
+    }
+
+    /**
+     * Get directive schema information
+     * Endpoint: GET /directives/schema
+     *
+     * Returns the expected schema for CEO directives
+     */
+    public function schema() {
+        Flight::json([
+            'success' => true,
+            'schema' => [
+                'required_fields' => CeoDirectiveService::getRequiredFields(),
+                'valid_directive_types' => CeoDirectiveService::getValidDirectiveTypes(),
+                'valid_priorities' => CeoDirectiveService::getValidPriorities(),
+                'optional_fields' => [
+                    'subject' => 'string',
+                    'metadata' => 'object',
+                    'expires_at' => 'string (ISO 8601)',
+                    'source' => 'string',
+                    'target_team' => 'string',
+                    'requires_acknowledgment' => 'boolean'
+                ],
+                'example' => [
+                    'directive_type' => 'strategic',
+                    'content' => 'We need to prioritize customer retention metrics for Q1 2024.',
+                    'priority' => 'high',
+                    'timestamp' => date('c'),
+                    'subject' => 'Q1 Priority Focus',
+                    'source' => 'ceo@company.com',
+                    'target_team' => 'engineering',
+                    'requires_acknowledgment' => true
+                ]
+            ]
+        ]);
+    }
+
+    /**
+     * Validate a directive without queueing it
+     * Endpoint: POST /directives/validate
+     *
+     * Useful for testing directive format before sending
+     */
+    public function validateOnly() {
+        // Only accept POST requests
+        if (Flight::request()->method !== 'POST') {
+            Flight::response()->status(405);
+            Flight::json([
+                'success' => false,
+                'error' => 'Method not allowed. Use POST.'
+            ]);
+            return;
+        }
+
+        // Get raw payload
+        $payload = file_get_contents('php://input');
+
+        if (empty($payload)) {
+            Flight::response()->status(400);
+            Flight::json([
+                'success' => false,
+                'error' => 'Empty request body'
+            ]);
+            return;
+        }
+
+        // Parse JSON
+        $directive = json_decode($payload, true);
+        if ($directive === null && json_last_error() !== JSON_ERROR_NONE) {
+            Flight::response()->status(400);
+            Flight::json([
+                'success' => false,
+                'error' => 'Invalid JSON: ' . json_last_error_msg()
+            ]);
+            return;
+        }
+
+        // Validate the directive
+        $validation = $this->directiveService->validate($directive);
+
+        $statusCode = $validation['valid'] ? 200 : 400;
+        Flight::response()->status($statusCode);
+
+        Flight::json([
+            'success' => $validation['valid'],
+            'valid' => $validation['valid'],
+            'errors' => $validation['errors'],
+            'warnings' => $validation['warnings'],
+            'error_summary' => $validation['valid'] ? null : $this->buildErrorSummary($validation['errors'])
+        ]);
+    }
+
+    /**
+     * Build a human-readable error summary
+     *
+     * @param array $errors Array of error objects
+     * @return string Human-readable error summary
+     */
+    private function buildErrorSummary(array $errors): string {
+        $missingFields = [];
+        $typeMismatches = [];
+        $otherErrors = [];
+
+        foreach ($errors as $error) {
+            switch ($error['error']) {
+                case 'missing_field':
+                case 'empty_field':
+                    $missingFields[] = $error['field'];
+                    break;
+                case 'type_mismatch':
+                    $typeMismatches[] = "{$error['field']} (expected {$error['expected_type']}, got {$error['actual_type']})";
+                    break;
+                default:
+                    $otherErrors[] = $error['message'];
+            }
+        }
+
+        $parts = [];
+
+        if (!empty($missingFields)) {
+            $parts[] = 'Missing required fields: ' . implode(', ', $missingFields);
+        }
+
+        if (!empty($typeMismatches)) {
+            $parts[] = 'Type mismatches: ' . implode('; ', $typeMismatches);
+        }
+
+        if (!empty($otherErrors)) {
+            $parts[] = implode('. ', $otherErrors);
+        }
+
+        return implode('. ', $parts);
+    }
+}

--- a/routes/directives.php
+++ b/routes/directives.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Directives Routes
+ *
+ * Routes for CEO directive endpoints.
+ */
+
+use \Flight as Flight;
+
+// CEO Directive endpoints
+Flight::route('POST /directives/receive', ['\app\Directives', 'receive']);
+Flight::route('GET /directives/schema', ['\app\Directives', 'schema']);
+Flight::route('POST /directives/validate', ['\app\Directives', 'validateOnly']);
+
+// Fall through to default routes for other /directives/* paths
+Flight::defaultRoute();

--- a/services/CeoDirectiveService.php
+++ b/services/CeoDirectiveService.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * CEO Directive Service
+ *
+ * Handles validation and processing of incoming CEO directive messages.
+ * Ensures directives contain required fields and are in the expected format
+ * before queuing them for processing.
+ */
+
+namespace app\services;
+
+use \Flight as Flight;
+use \app\Bean;
+
+class CeoDirectiveService {
+
+    private $logger;
+
+    /**
+     * Required fields for a CEO directive with their expected types
+     * Types: 'string', 'integer', 'array', 'boolean'
+     */
+    private const REQUIRED_FIELDS = [
+        'directive_type' => 'string',
+        'content' => 'string',
+        'priority' => 'string',
+        'timestamp' => 'string'
+    ];
+
+    /**
+     * Optional fields with their expected types
+     */
+    private const OPTIONAL_FIELDS = [
+        'subject' => 'string',
+        'metadata' => 'array',
+        'expires_at' => 'string',
+        'source' => 'string',
+        'target_team' => 'string',
+        'requires_acknowledgment' => 'boolean'
+    ];
+
+    /**
+     * Valid directive types
+     */
+    private const VALID_DIRECTIVE_TYPES = [
+        'strategic',
+        'operational',
+        'urgent',
+        'informational',
+        'action_required'
+    ];
+
+    /**
+     * Valid priority levels
+     */
+    private const VALID_PRIORITIES = [
+        'critical',
+        'high',
+        'medium',
+        'low'
+    ];
+
+    public function __construct() {
+        $this->logger = Flight::get('log');
+    }
+
+    /**
+     * Validate a CEO directive message
+     *
+     * @param array $directive The directive data to validate
+     * @return array Validation result with 'valid', 'errors', and 'warnings' keys
+     */
+    public function validate(array $directive): array {
+        $errors = [];
+        $warnings = [];
+
+        // Check for missing required fields
+        foreach (self::REQUIRED_FIELDS as $field => $expectedType) {
+            if (!array_key_exists($field, $directive)) {
+                $errors[] = [
+                    'field' => $field,
+                    'error' => 'missing_field',
+                    'message' => "Required field '{$field}' is missing"
+                ];
+            } elseif ($directive[$field] === null || $directive[$field] === '') {
+                $errors[] = [
+                    'field' => $field,
+                    'error' => 'empty_field',
+                    'message' => "Required field '{$field}' cannot be empty"
+                ];
+            } else {
+                // Check type
+                $typeError = $this->validateType($field, $directive[$field], $expectedType);
+                if ($typeError) {
+                    $errors[] = $typeError;
+                }
+            }
+        }
+
+        // Validate optional fields if present
+        foreach (self::OPTIONAL_FIELDS as $field => $expectedType) {
+            if (array_key_exists($field, $directive) && $directive[$field] !== null) {
+                $typeError = $this->validateType($field, $directive[$field], $expectedType);
+                if ($typeError) {
+                    $errors[] = $typeError;
+                }
+            }
+        }
+
+        // Validate directive_type if present and valid type
+        if (isset($directive['directive_type']) && is_string($directive['directive_type'])) {
+            if (!in_array($directive['directive_type'], self::VALID_DIRECTIVE_TYPES, true)) {
+                $errors[] = [
+                    'field' => 'directive_type',
+                    'error' => 'invalid_value',
+                    'message' => "Invalid directive_type '{$directive['directive_type']}'. Valid types: " . implode(', ', self::VALID_DIRECTIVE_TYPES)
+                ];
+            }
+        }
+
+        // Validate priority if present and valid type
+        if (isset($directive['priority']) && is_string($directive['priority'])) {
+            if (!in_array($directive['priority'], self::VALID_PRIORITIES, true)) {
+                $errors[] = [
+                    'field' => 'priority',
+                    'error' => 'invalid_value',
+                    'message' => "Invalid priority '{$directive['priority']}'. Valid priorities: " . implode(', ', self::VALID_PRIORITIES)
+                ];
+            }
+        }
+
+        // Validate timestamp format (ISO 8601)
+        if (isset($directive['timestamp']) && is_string($directive['timestamp'])) {
+            $timestampValid = $this->validateTimestamp($directive['timestamp']);
+            if (!$timestampValid) {
+                $errors[] = [
+                    'field' => 'timestamp',
+                    'error' => 'invalid_format',
+                    'message' => "Invalid timestamp format. Expected ISO 8601 format (e.g., '2024-01-15T10:30:00Z')"
+                ];
+            }
+        }
+
+        // Validate expires_at format if present
+        if (isset($directive['expires_at']) && is_string($directive['expires_at']) && !empty($directive['expires_at'])) {
+            $expiresValid = $this->validateTimestamp($directive['expires_at']);
+            if (!$expiresValid) {
+                $warnings[] = [
+                    'field' => 'expires_at',
+                    'warning' => 'invalid_format',
+                    'message' => "Invalid expires_at format. Expected ISO 8601 format"
+                ];
+            }
+        }
+
+        // Validate content length
+        if (isset($directive['content']) && is_string($directive['content'])) {
+            if (strlen($directive['content']) > 50000) {
+                $errors[] = [
+                    'field' => 'content',
+                    'error' => 'content_too_long',
+                    'message' => 'Content exceeds maximum length of 50000 characters'
+                ];
+            }
+            if (strlen($directive['content']) < 10) {
+                $warnings[] = [
+                    'field' => 'content',
+                    'warning' => 'content_too_short',
+                    'message' => 'Content is very short (less than 10 characters)'
+                ];
+            }
+        }
+
+        // Log validation attempt
+        if (!empty($errors)) {
+            $this->logger->warning('CEO directive validation failed', [
+                'error_count' => count($errors),
+                'errors' => $errors,
+                'directive_type' => $directive['directive_type'] ?? 'unknown'
+            ]);
+        }
+
+        return [
+            'valid' => empty($errors),
+            'errors' => $errors,
+            'warnings' => $warnings
+        ];
+    }
+
+    /**
+     * Validate the type of a field value
+     *
+     * @param string $field Field name
+     * @param mixed $value The value to check
+     * @param string $expectedType Expected type
+     * @return array|null Error array if type mismatch, null if valid
+     */
+    private function validateType(string $field, $value, string $expectedType): ?array {
+        $actualType = gettype($value);
+
+        $typeMap = [
+            'string' => 'string',
+            'integer' => 'integer',
+            'array' => 'array',
+            'boolean' => 'boolean'
+        ];
+
+        $expectedPhpType = $typeMap[$expectedType] ?? $expectedType;
+
+        // Handle integer that might come as string from JSON
+        if ($expectedType === 'integer' && is_string($value) && ctype_digit($value)) {
+            return null; // Accept numeric strings for integers
+        }
+
+        // Handle boolean that might come as string
+        if ($expectedType === 'boolean' && is_string($value)) {
+            if (in_array(strtolower($value), ['true', 'false', '1', '0'], true)) {
+                return null; // Accept string representations of boolean
+            }
+        }
+
+        if ($actualType !== $expectedPhpType) {
+            return [
+                'field' => $field,
+                'error' => 'type_mismatch',
+                'message' => "Field '{$field}' expected type '{$expectedType}', got '{$actualType}'",
+                'expected_type' => $expectedType,
+                'actual_type' => $actualType
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate ISO 8601 timestamp format
+     *
+     * @param string $timestamp The timestamp string to validate
+     * @return bool True if valid ISO 8601 format
+     */
+    private function validateTimestamp(string $timestamp): bool {
+        // Try to parse as DateTime
+        $parsed = \DateTime::createFromFormat(\DateTime::ATOM, $timestamp);
+        if ($parsed !== false) {
+            return true;
+        }
+
+        // Try alternate ISO 8601 formats
+        $formats = [
+            'Y-m-d\TH:i:sP',      // 2024-01-15T10:30:00+00:00
+            'Y-m-d\TH:i:s.uP',    // 2024-01-15T10:30:00.000+00:00
+            'Y-m-d\TH:i:s\Z',     // 2024-01-15T10:30:00Z
+            'Y-m-d\TH:i:sO',      // 2024-01-15T10:30:00+0000
+            'Y-m-d H:i:s',        // 2024-01-15 10:30:00
+        ];
+
+        foreach ($formats as $format) {
+            $parsed = \DateTime::createFromFormat($format, $timestamp);
+            if ($parsed !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Parse and queue a valid directive for processing
+     *
+     * @param array $directive The validated directive data
+     * @param int|null $memberId Optional member ID for association
+     * @return array Result with 'success', 'directive_id', and 'error' keys
+     */
+    public function parseAndQueue(array $directive, ?int $memberId = null): array {
+        // Validate first
+        $validation = $this->validate($directive);
+        if (!$validation['valid']) {
+            return [
+                'success' => false,
+                'error' => 'Validation failed',
+                'validation_errors' => $validation['errors']
+            ];
+        }
+
+        try {
+            // Create new CEO directive record
+            $directiveBean = Bean::dispense('ceodirectives');
+
+            // Set required fields
+            $directiveBean->directive_type = $directive['directive_type'];
+            $directiveBean->content = $directive['content'];
+            $directiveBean->priority = $directive['priority'];
+            $directiveBean->received_at = $directive['timestamp'];
+
+            // Set optional fields if present
+            if (isset($directive['subject'])) {
+                $directiveBean->subject = $directive['subject'];
+            }
+            if (isset($directive['metadata']) && is_array($directive['metadata'])) {
+                $directiveBean->metadata_json = json_encode($directive['metadata']);
+            }
+            if (isset($directive['expires_at'])) {
+                $directiveBean->expires_at = $directive['expires_at'];
+            }
+            if (isset($directive['source'])) {
+                $directiveBean->source = $directive['source'];
+            }
+            if (isset($directive['target_team'])) {
+                $directiveBean->target_team = $directive['target_team'];
+            }
+            if (isset($directive['requires_acknowledgment'])) {
+                $directiveBean->requires_acknowledgment = $directive['requires_acknowledgment'] ? 1 : 0;
+            }
+
+            // Set processing metadata
+            $directiveBean->status = 'queued';
+            $directiveBean->created_at = date('Y-m-d H:i:s');
+            $directiveBean->updated_at = date('Y-m-d H:i:s');
+
+            if ($memberId !== null) {
+                $directiveBean->member_id = $memberId;
+            }
+
+            // Store the directive
+            $directiveId = Bean::store($directiveBean);
+
+            $this->logger->info('CEO directive queued for processing', [
+                'directive_id' => $directiveId,
+                'directive_type' => $directive['directive_type'],
+                'priority' => $directive['priority'],
+                'member_id' => $memberId
+            ]);
+
+            return [
+                'success' => true,
+                'directive_id' => $directiveId,
+                'status' => 'queued',
+                'warnings' => $validation['warnings']
+            ];
+
+        } catch (\Exception $e) {
+            $this->logger->error('Failed to queue CEO directive', [
+                'error' => $e->getMessage(),
+                'directive_type' => $directive['directive_type'] ?? 'unknown'
+            ]);
+
+            return [
+                'success' => false,
+                'error' => 'Failed to store directive: ' . $e->getMessage()
+            ];
+        }
+    }
+
+    /**
+     * Get valid directive types
+     *
+     * @return array List of valid directive types
+     */
+    public static function getValidDirectiveTypes(): array {
+        return self::VALID_DIRECTIVE_TYPES;
+    }
+
+    /**
+     * Get valid priority levels
+     *
+     * @return array List of valid priority levels
+     */
+    public static function getValidPriorities(): array {
+        return self::VALID_PRIORITIES;
+    }
+
+    /**
+     * Get required fields schema
+     *
+     * @return array Required fields with their types
+     */
+    public static function getRequiredFields(): array {
+        return self::REQUIRED_FIELDS;
+    }
+}

--- a/tests/CeoDirectiveValidationTest.php
+++ b/tests/CeoDirectiveValidationTest.php
@@ -1,0 +1,561 @@
+<?php
+/**
+ * CEO Directive Validation Unit Tests
+ *
+ * Tests the CeoDirectiveService validation logic.
+ * Run with: php tests/CeoDirectiveValidationTest.php
+ */
+
+namespace app\tests;
+
+// Minimal Flight mock for testing without full bootstrap
+if (!class_exists('\Flight')) {
+    class FlightMock {
+        private static $values = [];
+
+        public static function get($key) {
+            return self::$values[$key] ?? null;
+        }
+
+        public static function set($key, $value) {
+            self::$values[$key] = $value;
+        }
+    }
+    class_alias('app\tests\FlightMock', 'Flight');
+}
+
+// Minimal logger mock
+class LoggerMock {
+    public function debug($msg, $ctx = []) {}
+    public function info($msg, $ctx = []) {}
+    public function warning($msg, $ctx = []) {}
+    public function error($msg, $ctx = []) {}
+}
+
+// Set up mock logger
+\Flight::set('log', new LoggerMock());
+
+require_once __DIR__ . '/../services/CeoDirectiveService.php';
+
+use app\services\CeoDirectiveService;
+
+class CeoDirectiveValidationTest {
+
+    private static int $passed = 0;
+    private static int $failed = 0;
+    private static array $errors = [];
+
+    /**
+     * Run all tests
+     */
+    public static function run(): void {
+        echo "=== CEO Directive Validation Unit Tests ===\n\n";
+
+        // Run validation tests
+        self::testValidDirectivePasses();
+        self::testMissingRequiredFields();
+        self::testEmptyRequiredFields();
+        self::testTypeMismatchString();
+        self::testTypeMismatchArray();
+        self::testTypeMismatchBoolean();
+        self::testInvalidDirectiveType();
+        self::testInvalidPriority();
+        self::testInvalidTimestampFormat();
+        self::testValidTimestampFormats();
+        self::testContentTooLong();
+        self::testContentTooShortWarning();
+        self::testOptionalFieldsAccepted();
+        self::testUnknownFieldsIgnored();
+        self::testMultipleErrors();
+
+        self::printResults();
+    }
+
+    /**
+     * Test that a properly formatted directive passes validation
+     */
+    private static function testValidDirectivePasses(): void {
+        echo "Testing valid directive passes validation...\n";
+
+        $service = new CeoDirectiveService();
+
+        $validDirective = [
+            'directive_type' => 'strategic',
+            'content' => 'We need to prioritize customer retention metrics for Q1 2024. This is a strategic initiative.',
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z'
+        ];
+
+        $result = $service->validate($validDirective);
+
+        self::assertTrue($result['valid'], 'Valid directive should pass validation');
+        self::assertEqual(count($result['errors']), 0, 'No errors for valid directive');
+
+        echo "\n";
+    }
+
+    /**
+     * Test that missing required fields are detected
+     */
+    private static function testMissingRequiredFields(): void {
+        echo "Testing missing required fields detection...\n";
+
+        $service = new CeoDirectiveService();
+
+        // Missing all required fields
+        $emptyDirective = [];
+        $result = $service->validate($emptyDirective);
+
+        self::assertFalse($result['valid'], 'Empty directive should fail validation');
+        self::assertEqual(count($result['errors']), 4, 'Should have 4 missing field errors');
+
+        // Check each missing field is reported
+        $missingFields = array_column($result['errors'], 'field');
+        self::assertTrue(in_array('directive_type', $missingFields), 'Missing directive_type reported');
+        self::assertTrue(in_array('content', $missingFields), 'Missing content reported');
+        self::assertTrue(in_array('priority', $missingFields), 'Missing priority reported');
+        self::assertTrue(in_array('timestamp', $missingFields), 'Missing timestamp reported');
+
+        // Verify error type
+        foreach ($result['errors'] as $error) {
+            self::assertEqual($error['error'], 'missing_field', "Error type is 'missing_field'");
+        }
+
+        echo "\n";
+    }
+
+    /**
+     * Test that empty required fields are detected
+     */
+    private static function testEmptyRequiredFields(): void {
+        echo "Testing empty required fields detection...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => '',
+            'content' => '',
+            'priority' => '',
+            'timestamp' => ''
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'Empty fields should fail validation');
+        self::assertTrue(count($result['errors']) >= 4, 'Should have at least 4 errors');
+
+        // Count empty_field errors specifically
+        $emptyFieldErrors = array_filter($result['errors'], fn($e) => $e['error'] === 'empty_field');
+        self::assertEqual(count($emptyFieldErrors), 4, 'Should have 4 empty_field errors');
+
+        // Verify all required fields have empty_field errors
+        $emptyFields = array_column($emptyFieldErrors, 'field');
+        self::assertTrue(in_array('directive_type', $emptyFields), 'directive_type has empty_field error');
+        self::assertTrue(in_array('content', $emptyFields), 'content has empty_field error');
+        self::assertTrue(in_array('priority', $emptyFields), 'priority has empty_field error');
+        self::assertTrue(in_array('timestamp', $emptyFields), 'timestamp has empty_field error');
+
+        echo "\n";
+    }
+
+    /**
+     * Test type mismatch for string fields
+     */
+    private static function testTypeMismatchString(): void {
+        echo "Testing type mismatch for string fields...\n";
+
+        $service = new CeoDirectiveService();
+
+        // Pass array instead of string
+        $directive = [
+            'directive_type' => ['not', 'a', 'string'],
+            'content' => 'Valid content here that is long enough.',
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z'
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'Array in string field should fail');
+
+        $typeErrors = array_filter($result['errors'], fn($e) => $e['error'] === 'type_mismatch');
+        self::assertTrue(count($typeErrors) >= 1, 'Should have type mismatch error');
+
+        $firstError = reset($typeErrors);
+        self::assertEqual($firstError['field'], 'directive_type', 'Error on directive_type field');
+        self::assertEqual($firstError['expected_type'], 'string', 'Expected type is string');
+        self::assertEqual($firstError['actual_type'], 'array', 'Actual type is array');
+
+        echo "\n";
+    }
+
+    /**
+     * Test type mismatch for array fields
+     */
+    private static function testTypeMismatchArray(): void {
+        echo "Testing type mismatch for array fields (metadata)...\n";
+
+        $service = new CeoDirectiveService();
+
+        // Pass string instead of array for metadata
+        $directive = [
+            'directive_type' => 'strategic',
+            'content' => 'Valid content here that is long enough.',
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z',
+            'metadata' => 'not an array'
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'String in array field should fail');
+
+        $typeErrors = array_filter($result['errors'], fn($e) => $e['error'] === 'type_mismatch' && $e['field'] === 'metadata');
+        self::assertTrue(count($typeErrors) >= 1, 'Should have type mismatch error for metadata');
+
+        $error = reset($typeErrors);
+        self::assertEqual($error['expected_type'], 'array', 'Expected type is array');
+        self::assertEqual($error['actual_type'], 'string', 'Actual type is string');
+
+        echo "\n";
+    }
+
+    /**
+     * Test type mismatch for boolean fields
+     */
+    private static function testTypeMismatchBoolean(): void {
+        echo "Testing type mismatch for boolean fields...\n";
+
+        $service = new CeoDirectiveService();
+
+        // Pass integer instead of boolean
+        $directive = [
+            'directive_type' => 'strategic',
+            'content' => 'Valid content here that is long enough.',
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z',
+            'requires_acknowledgment' => 123
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'Integer in boolean field should fail');
+
+        $typeErrors = array_filter($result['errors'], fn($e) => $e['error'] === 'type_mismatch' && $e['field'] === 'requires_acknowledgment');
+        self::assertTrue(count($typeErrors) >= 1, 'Should have type mismatch error');
+
+        // Test that string "true" is accepted
+        $directive['requires_acknowledgment'] = 'true';
+        $result2 = $service->validate($directive);
+        self::assertTrue($result2['valid'], 'String "true" should be accepted for boolean');
+
+        echo "\n";
+    }
+
+    /**
+     * Test invalid directive type
+     */
+    private static function testInvalidDirectiveType(): void {
+        echo "Testing invalid directive type...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => 'invalid_type',
+            'content' => 'Valid content here that is long enough.',
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z'
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'Invalid directive type should fail');
+
+        $valueErrors = array_filter($result['errors'], fn($e) => $e['error'] === 'invalid_value' && $e['field'] === 'directive_type');
+        self::assertTrue(count($valueErrors) >= 1, 'Should have invalid value error');
+
+        echo "\n";
+    }
+
+    /**
+     * Test invalid priority
+     */
+    private static function testInvalidPriority(): void {
+        echo "Testing invalid priority...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => 'strategic',
+            'content' => 'Valid content here that is long enough.',
+            'priority' => 'super_urgent',
+            'timestamp' => '2024-01-15T10:30:00Z'
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'Invalid priority should fail');
+
+        $valueErrors = array_filter($result['errors'], fn($e) => $e['error'] === 'invalid_value' && $e['field'] === 'priority');
+        self::assertTrue(count($valueErrors) >= 1, 'Should have invalid value error for priority');
+
+        echo "\n";
+    }
+
+    /**
+     * Test invalid timestamp format
+     */
+    private static function testInvalidTimestampFormat(): void {
+        echo "Testing invalid timestamp format...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => 'strategic',
+            'content' => 'Valid content here that is long enough.',
+            'priority' => 'high',
+            'timestamp' => 'not a timestamp'
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'Invalid timestamp should fail');
+
+        $formatErrors = array_filter($result['errors'], fn($e) => $e['error'] === 'invalid_format' && $e['field'] === 'timestamp');
+        self::assertTrue(count($formatErrors) >= 1, 'Should have invalid format error');
+
+        echo "\n";
+    }
+
+    /**
+     * Test various valid timestamp formats
+     */
+    private static function testValidTimestampFormats(): void {
+        echo "Testing valid timestamp formats...\n";
+
+        $service = new CeoDirectiveService();
+
+        $validTimestamps = [
+            '2024-01-15T10:30:00Z',
+            '2024-01-15T10:30:00+00:00',
+            '2024-01-15T10:30:00-05:00',
+            '2024-01-15 10:30:00',
+        ];
+
+        foreach ($validTimestamps as $timestamp) {
+            $directive = [
+                'directive_type' => 'strategic',
+                'content' => 'Valid content here that is long enough.',
+                'priority' => 'high',
+                'timestamp' => $timestamp
+            ];
+
+            $result = $service->validate($directive);
+            self::assertTrue($result['valid'], "Timestamp '{$timestamp}' should be valid");
+        }
+
+        echo "\n";
+    }
+
+    /**
+     * Test content too long
+     */
+    private static function testContentTooLong(): void {
+        echo "Testing content too long...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => 'strategic',
+            'content' => str_repeat('x', 60000), // 60k chars, over 50k limit
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z'
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'Content over 50k should fail');
+
+        $lengthErrors = array_filter($result['errors'], fn($e) => $e['error'] === 'content_too_long');
+        self::assertTrue(count($lengthErrors) >= 1, 'Should have content_too_long error');
+
+        echo "\n";
+    }
+
+    /**
+     * Test content too short generates warning
+     */
+    private static function testContentTooShortWarning(): void {
+        echo "Testing content too short warning...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => 'strategic',
+            'content' => 'Short',  // Less than 10 chars
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z'
+        ];
+
+        $result = $service->validate($directive);
+
+        // Should still be valid, but have warning
+        self::assertTrue($result['valid'], 'Short content should still be valid');
+        self::assertTrue(count($result['warnings']) > 0, 'Should have warning for short content');
+
+        $shortWarnings = array_filter($result['warnings'], fn($w) => $w['warning'] === 'content_too_short');
+        self::assertTrue(count($shortWarnings) >= 1, 'Should have content_too_short warning');
+
+        echo "\n";
+    }
+
+    /**
+     * Test optional fields are accepted
+     */
+    private static function testOptionalFieldsAccepted(): void {
+        echo "Testing optional fields are accepted...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => 'strategic',
+            'content' => 'Valid content here that is long enough.',
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z',
+            'subject' => 'Q1 Priorities',
+            'metadata' => ['department' => 'engineering', 'category' => 'roadmap'],
+            'expires_at' => '2024-02-15T10:30:00Z',
+            'source' => 'ceo@company.com',
+            'target_team' => 'engineering',
+            'requires_acknowledgment' => true
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertTrue($result['valid'], 'Directive with all optional fields should be valid');
+        self::assertEqual(count($result['errors']), 0, 'No errors with optional fields');
+
+        echo "\n";
+    }
+
+    /**
+     * Test unknown fields are ignored
+     */
+    private static function testUnknownFieldsIgnored(): void {
+        echo "Testing unknown fields are ignored...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => 'strategic',
+            'content' => 'Valid content here that is long enough.',
+            'priority' => 'high',
+            'timestamp' => '2024-01-15T10:30:00Z',
+            'unknown_field' => 'some value',
+            'another_unknown' => 123
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertTrue($result['valid'], 'Unknown fields should be ignored');
+        self::assertEqual(count($result['errors']), 0, 'No errors for unknown fields');
+
+        echo "\n";
+    }
+
+    /**
+     * Test multiple errors are all reported
+     */
+    private static function testMultipleErrors(): void {
+        echo "Testing multiple errors are all reported...\n";
+
+        $service = new CeoDirectiveService();
+
+        $directive = [
+            'directive_type' => 'invalid_type',  // Invalid value
+            'content' => ['not', 'string'],       // Type mismatch
+            'priority' => 'super_urgent',         // Invalid value
+            // timestamp missing
+        ];
+
+        $result = $service->validate($directive);
+
+        self::assertFalse($result['valid'], 'Multiple errors should fail validation');
+        self::assertTrue(count($result['errors']) >= 3, 'Should have multiple errors');
+
+        // Should have at least: missing timestamp, invalid directive_type, type mismatch on content, invalid priority
+        $errorTypes = array_column($result['errors'], 'error');
+        self::assertTrue(in_array('missing_field', $errorTypes), 'Should have missing_field error');
+        self::assertTrue(in_array('type_mismatch', $errorTypes), 'Should have type_mismatch error');
+        self::assertTrue(in_array('invalid_value', $errorTypes), 'Should have invalid_value error');
+
+        echo "\n";
+    }
+
+    // === Helper Methods ===
+
+    /**
+     * Assert two values are equal
+     */
+    private static function assertEqual($actual, $expected, string $message): void {
+        if ($actual === $expected) {
+            self::$passed++;
+            echo "  [PASS] {$message}\n";
+        } else {
+            self::$failed++;
+            self::$errors[] = "{$message}: expected " . var_export($expected, true) . ", got " . var_export($actual, true);
+            echo "  [FAIL] {$message}\n";
+        }
+    }
+
+    /**
+     * Assert value is true
+     */
+    private static function assertTrue($value, string $message): void {
+        if ($value === true) {
+            self::$passed++;
+            echo "  [PASS] {$message}\n";
+        } else {
+            self::$failed++;
+            self::$errors[] = "{$message}: expected true, got " . var_export($value, true);
+            echo "  [FAIL] {$message}\n";
+        }
+    }
+
+    /**
+     * Assert value is false
+     */
+    private static function assertFalse($value, string $message): void {
+        if ($value === false) {
+            self::$passed++;
+            echo "  [PASS] {$message}\n";
+        } else {
+            self::$failed++;
+            self::$errors[] = "{$message}: expected false, got " . var_export($value, true);
+            echo "  [FAIL] {$message}\n";
+        }
+    }
+
+    /**
+     * Print test results summary
+     */
+    private static function printResults(): void {
+        $total = self::$passed + self::$failed;
+        echo "\n=== Test Results ===\n";
+        echo "Passed: " . self::$passed . "/{$total}\n";
+        echo "Failed: " . self::$failed . "/{$total}\n";
+
+        if (count(self::$errors) > 0) {
+            echo "\nErrors:\n";
+            foreach (self::$errors as $error) {
+                echo "  - {$error}\n";
+            }
+        }
+
+        echo "\n";
+        exit(self::$failed > 0 ? 1 : 0);
+    }
+}
+
+// Run tests
+CeoDirectiveValidationTest::run();


### PR DESCRIPTION
## Summary

Implements message validation to ensure CEO directives contain required fields and are in the expected format before processing.

Closes #22

## Changes

### New Files
- `services/CeoDirectiveService.php` - Core validation and parsing service
- `controls/Directives.php` - API controller for directive endpoints  
- `routes/directives.php` - FlightPHP route definitions
- `tests/CeoDirectiveValidationTest.php` - Comprehensive unit tests (55 assertions)

### Features
- **Required fields validation**: directive_type, content, priority, timestamp
- **Optional fields support**: subject, metadata, expires_at, source, target_team, requires_acknowledgment
- **Type validation** with detailed mismatch error messages
- **ISO 8601 timestamp validation** (multiple formats)
- **Content length validation** (10-50,000 characters)
- **Monolog integration** for validation failure logging

### API Endpoints
- `POST /directives/receive` - Validate and queue directive
- `POST /directives/validate` - Validate without queuing
- `GET /directives/schema` - Get expected schema

### Acceptance Criteria Met

**Scenario 1**: Valid directives pass validation and are queued (HTTP 201)

**Scenario 2**: Missing fields return specific error details:
```json
{
  "validation_errors": [
    {"field": "content", "error": "missing_field", "message": "Required field 'content' is missing"}
  ]
}
```

**Scenario 3**: Type mismatches return detailed errors:
```json
{
  "validation_errors": [
    {"field": "metadata", "error": "type_mismatch", "expected_type": "array", "actual_type": "string"}
  ]
}
```

## Test Plan

- [x] Unit tests pass (55/55 assertions)
- [x] PHP syntax validation passes
- [ ] Manual API testing with valid/invalid payloads
- [ ] Review logging output for validation failures