### PR TITLE
Add ResponseFormatterService for standardized CEO directive responses

### DIFF
--- a/services/ResponseFormatterService.php
+++ b/services/ResponseFormatterService.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Response Formatter Service
+ * Generates consistent, structured responses for CEO directives with proper status indicators
+ *
+ * @see GitHub Issue #23
+ */
+
+namespace app\services;
+
+class ResponseFormatterService {
+
+    /** Response status constants */
+    public const STATUS_SUCCESS = 'success';
+    public const STATUS_ERROR = 'error';
+    public const STATUS_PENDING = 'pending';
+
+    /** Error code constants */
+    public const ERROR_VALIDATION = 'VALIDATION_ERROR';
+    public const ERROR_PROCESSING = 'PROCESSING_ERROR';
+    public const ERROR_NOT_FOUND = 'NOT_FOUND';
+    public const ERROR_UNAUTHORIZED = 'UNAUTHORIZED';
+    public const ERROR_INTERNAL = 'INTERNAL_ERROR';
+
+    /**
+     * Generate a success response for a processed CEO directive
+     *
+     * @param string $directiveId The unique identifier for the directive
+     * @param string $message Confirmation message
+     * @param array $additionalData Optional additional data to include
+     * @return array Formatted success response
+     */
+    public static function success(string $directiveId, string $message, array $additionalData = []): array {
+        return self::formatResponse([
+            'status' => self::STATUS_SUCCESS,
+            'timestamp' => self::getTimestamp(),
+            'directiveId' => $directiveId,
+            'message' => $message,
+            'data' => $additionalData
+        ]);
+    }
+
+    /**
+     * Generate an error response for a failed CEO directive
+     *
+     * @param string $errorCode Error code identifier
+     * @param string $message Descriptive error message
+     * @param array $suggestedNextSteps Array of suggested actions to resolve the error
+     * @param string|null $directiveId Optional directive ID if available
+     * @return array Formatted error response
+     */
+    public static function error(
+        string $errorCode,
+        string $message,
+        array $suggestedNextSteps = [],
+        ?string $directiveId = null
+    ): array {
+        return self::formatResponse([
+            'status' => self::STATUS_ERROR,
+            'timestamp' => self::getTimestamp(),
+            'directiveId' => $directiveId,
+            'error' => [
+                'code' => $errorCode,
+                'message' => $message,
+                'suggestedNextSteps' => $suggestedNextSteps
+            ]
+        ]);
+    }
+
+    /**
+     * Generate a pending response for a directive in progress
+     *
+     * @param string $directiveId The unique identifier for the directive
+     * @param string $message Status message
+     * @param int|null $progressPercent Optional progress percentage (0-100)
+     * @return array Formatted pending response
+     */
+    public static function pending(string $directiveId, string $message, ?int $progressPercent = null): array {
+        $response = [
+            'status' => self::STATUS_PENDING,
+            'timestamp' => self::getTimestamp(),
+            'directiveId' => $directiveId,
+            'message' => $message
+        ];
+
+        if ($progressPercent !== null) {
+            $response['progress'] = max(0, min(100, $progressPercent));
+        }
+
+        return self::formatResponse($response);
+    }
+
+    /**
+     * Generate a validation error response
+     *
+     * @param string $message Error message
+     * @param array $validationErrors Specific field validation errors
+     * @param string|null $directiveId Optional directive ID
+     * @return array Formatted validation error response
+     */
+    public static function validationError(string $message, array $validationErrors = [], ?string $directiveId = null): array {
+        return self::error(
+            self::ERROR_VALIDATION,
+            $message,
+            ['Review and correct the invalid fields', 'Resubmit the directive with valid data'],
+            $directiveId
+        ) + ['validationErrors' => $validationErrors];
+    }
+
+    /**
+     * Generate a not found error response
+     *
+     * @param string $resource The resource that was not found
+     * @param string|null $directiveId Optional directive ID
+     * @return array Formatted not found error response
+     */
+    public static function notFound(string $resource, ?string $directiveId = null): array {
+        return self::error(
+            self::ERROR_NOT_FOUND,
+            "The requested {$resource} was not found",
+            ['Verify the identifier is correct', 'Check if the resource exists', 'Contact support if the issue persists'],
+            $directiveId
+        );
+    }
+
+    /**
+     * Format response to ensure it conforms to the JSON schema
+     *
+     * @param array $response Raw response data
+     * @return array Formatted response conforming to schema
+     */
+    private static function formatResponse(array $response): array {
+        // Ensure required fields are present
+        $formatted = [
+            'version' => '1.0',
+            'status' => $response['status'] ?? self::STATUS_ERROR,
+            'timestamp' => $response['timestamp'] ?? self::getTimestamp(),
+        ];
+
+        // Add directiveId if present
+        if (isset($response['directiveId'])) {
+            $formatted['directiveId'] = $response['directiveId'];
+        }
+
+        // Add message if present
+        if (isset($response['message'])) {
+            $formatted['message'] = $response['message'];
+        }
+
+        // Add data if present and not empty
+        if (!empty($response['data'])) {
+            $formatted['data'] = $response['data'];
+        }
+
+        // Add error details if present
+        if (isset($response['error'])) {
+            $formatted['error'] = $response['error'];
+        }
+
+        // Add progress if present
+        if (isset($response['progress'])) {
+            $formatted['progress'] = $response['progress'];
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * Get current timestamp in ISO 8601 format
+     *
+     * @return string ISO 8601 formatted timestamp
+     */
+    private static function getTimestamp(): string {
+        return date('c');
+    }
+
+    /**
+     * Convert response to JSON string
+     *
+     * @param array $response Response array
+     * @param bool $prettyPrint Whether to format JSON for readability
+     * @return string JSON encoded response
+     */
+    public static function toJson(array $response, bool $prettyPrint = false): string {
+        $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+        if ($prettyPrint) {
+            $options |= JSON_PRETTY_PRINT;
+        }
+        return json_encode($response, $options);
+    }
+
+    /**
+     * Validate that a response conforms to the expected schema
+     *
+     * @param array $response Response to validate
+     * @return bool True if valid, false otherwise
+     */
+    public static function isValidResponse(array $response): bool {
+        // Required fields
+        $requiredFields = ['version', 'status', 'timestamp'];
+
+        foreach ($requiredFields as $field) {
+            if (!isset($response[$field])) {
+                return false;
+            }
+        }
+
+        // Validate status is one of the allowed values
+        $validStatuses = [self::STATUS_SUCCESS, self::STATUS_ERROR, self::STATUS_PENDING];
+        if (!in_array($response['status'], $validStatuses, true)) {
+            return false;
+        }
+
+        // If status is success, message should be present
+        if ($response['status'] === self::STATUS_SUCCESS && !isset($response['message'])) {
+            return false;
+        }
+
+        // If status is error, error details should be present
+        if ($response['status'] === self::STATUS_ERROR && !isset($response['error'])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the JSON schema definition for CEO directive responses
+     *
+     * @return array JSON schema as associative array
+     */
+    public static function getSchema(): array {
+        return [
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+            'title' => 'CEO Directive Response',
+            'description' => 'Standardized response format for CEO directive acknowledgments',
+            'type' => 'object',
+            'required' => ['version', 'status', 'timestamp'],
+            'properties' => [
+                'version' => [
+                    'type' => 'string',
+                    'description' => 'Response format version',
+                    'const' => '1.0'
+                ],
+                'status' => [
+                    'type' => 'string',
+                    'description' => 'Response status indicator',
+                    'enum' => [self::STATUS_SUCCESS, self::STATUS_ERROR, self::STATUS_PENDING]
+                ],
+                'timestamp' => [
+                    'type' => 'string',
+                    'format' => 'date-time',
+                    'description' => 'ISO 8601 formatted timestamp of the response'
+                ],
+                'directiveId' => [
+                    'type' => 'string',
+                    'description' => 'Unique identifier for the CEO directive'
+                ],
+                'message' => [
+                    'type' => 'string',
+                    'description' => 'Human-readable confirmation or status message'
+                ],
+                'data' => [
+                    'type' => 'object',
+                    'description' => 'Additional data related to the response'
+                ],
+                'progress' => [
+                    'type' => 'integer',
+                    'minimum' => 0,
+                    'maximum' => 100,
+                    'description' => 'Progress percentage for pending operations'
+                ],
+                'error' => [
+                    'type' => 'object',
+                    'description' => 'Error details when status is error',
+                    'required' => ['code', 'message'],
+                    'properties' => [
+                        'code' => [
+                            'type' => 'string',
+                            'description' => 'Machine-readable error code'
+                        ],
+                        'message' => [
+                            'type' => 'string',
+                            'description' => 'Human-readable error description'
+                        ],
+                        'suggestedNextSteps' => [
+                            'type' => 'array',
+                            'items' => ['type' => 'string'],
+                            'description' => 'Suggested actions to resolve the error'
+                        ]
+                    ]
+                ]
+            ],
+            'if' => [
+                'properties' => ['status' => ['const' => self::STATUS_SUCCESS]]
+            ],
+            'then' => [
+                'required' => ['version', 'status', 'timestamp', 'message']
+            ],
+            'else' => [
+                'if' => [
+                    'properties' => ['status' => ['const' => self::STATUS_ERROR]]
+                ],
+                'then' => [
+                    'required' => ['version', 'status', 'timestamp', 'error']
+                ]
+            ]
+        ];
+    }
+}

--- a/tests/ResponseFormatterServiceTest.php
+++ b/tests/ResponseFormatterServiceTest.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * ResponseFormatterService Unit Tests
+ *
+ * Tests the ResponseFormatterService for generating standardized CEO directive responses.
+ * Run with: php tests/ResponseFormatterServiceTest.php
+ *
+ * @see GitHub Issue #23
+ */
+
+namespace app\tests;
+
+require_once __DIR__ . '/../services/ResponseFormatterService.php';
+
+use app\services\ResponseFormatterService;
+
+class ResponseFormatterServiceTest {
+
+    private static int $passed = 0;
+    private static int $failed = 0;
+    private static array $errors = [];
+
+    /**
+     * Run all tests
+     */
+    public static function run(): void {
+        echo "=== ResponseFormatterService Unit Tests ===\n\n";
+
+        // Run tests for acceptance criteria
+        self::testSuccessResponse();
+        self::testErrorResponse();
+        self::testResponseSchema();
+        self::testPendingResponse();
+        self::testValidationErrorResponse();
+        self::testNotFoundResponse();
+        self::testJsonConversion();
+        self::testResponseValidation();
+
+        self::printResults();
+    }
+
+    /**
+     * Test Scenario 1: Success response generation
+     * Given: A CEO directive has been successfully processed
+     * When: The system generates a response
+     * Then: The response contains success status, timestamp, directive ID, and confirmation message
+     */
+    private static function testSuccessResponse(): void {
+        echo "Testing success response (Scenario 1)...\n";
+
+        $directiveId = 'DIR-2024-001';
+        $message = 'Directive successfully processed and acknowledged';
+        $additionalData = ['processingTime' => '1.5s'];
+
+        $response = ResponseFormatterService::success($directiveId, $message, $additionalData);
+
+        // Check required fields
+        self::assertEqual($response['status'], ResponseFormatterService::STATUS_SUCCESS, 'Success status');
+        self::assertTrue(isset($response['timestamp']), 'Timestamp present');
+        self::assertEqual($response['directiveId'], $directiveId, 'Directive ID');
+        self::assertEqual($response['message'], $message, 'Confirmation message');
+        self::assertEqual($response['data'], $additionalData, 'Additional data');
+        self::assertEqual($response['version'], '1.0', 'Version number');
+
+        // Validate timestamp format (ISO 8601)
+        self::assertTimestampFormat($response['timestamp'], 'ISO 8601 timestamp format');
+
+        echo "\n";
+    }
+
+    /**
+     * Test Scenario 2: Error response generation
+     * Given: A CEO directive processing fails
+     * When: The system generates an error response
+     * Then: The response contains error status, error code, descriptive message, and suggested next steps
+     */
+    private static function testErrorResponse(): void {
+        echo "Testing error response (Scenario 2)...\n";
+
+        $errorCode = ResponseFormatterService::ERROR_PROCESSING;
+        $message = 'Unable to process directive due to system constraints';
+        $suggestedNextSteps = [
+            'Retry the operation after 5 minutes',
+            'Contact technical support if issue persists',
+            'Check system status page for outages'
+        ];
+        $directiveId = 'DIR-2024-002';
+
+        $response = ResponseFormatterService::error($errorCode, $message, $suggestedNextSteps, $directiveId);
+
+        // Check required fields
+        self::assertEqual($response['status'], ResponseFormatterService::STATUS_ERROR, 'Error status');
+        self::assertTrue(isset($response['timestamp']), 'Timestamp present');
+        self::assertTrue(isset($response['error']), 'Error object present');
+        self::assertEqual($response['error']['code'], $errorCode, 'Error code');
+        self::assertEqual($response['error']['message'], $message, 'Error message');
+        self::assertEqual($response['error']['suggestedNextSteps'], $suggestedNextSteps, 'Suggested next steps');
+        self::assertEqual($response['directiveId'], $directiveId, 'Directive ID');
+
+        echo "\n";
+    }
+
+    /**
+     * Test Scenario 3: Response schema conformance
+     * Given: The response is generated
+     * When: The system formats the response
+     * Then: The response follows the predefined JSON schema with all required fields
+     */
+    private static function testResponseSchema(): void {
+        echo "Testing response schema conformance (Scenario 3)...\n";
+
+        // Get schema
+        $schema = ResponseFormatterService::getSchema();
+        self::assertTrue(isset($schema['$schema']), 'Schema has $schema property');
+        self::assertTrue(isset($schema['required']), 'Schema has required fields');
+        self::assertTrue(in_array('version', $schema['required']), 'Schema requires version');
+        self::assertTrue(in_array('status', $schema['required']), 'Schema requires status');
+        self::assertTrue(in_array('timestamp', $schema['required']), 'Schema requires timestamp');
+
+        // Test success response conforms to schema
+        $successResponse = ResponseFormatterService::success('DIR-001', 'Test message');
+        self::assertTrue(ResponseFormatterService::isValidResponse($successResponse), 'Success response validates');
+
+        // Test error response conforms to schema
+        $errorResponse = ResponseFormatterService::error(
+            ResponseFormatterService::ERROR_INTERNAL,
+            'Test error'
+        );
+        self::assertTrue(ResponseFormatterService::isValidResponse($errorResponse), 'Error response validates');
+
+        // Test pending response conforms to schema
+        $pendingResponse = ResponseFormatterService::pending('DIR-001', 'Processing');
+        self::assertTrue(ResponseFormatterService::isValidResponse($pendingResponse), 'Pending response validates');
+
+        echo "\n";
+    }
+
+    /**
+     * Test pending response generation
+     */
+    private static function testPendingResponse(): void {
+        echo "Testing pending response...\n";
+
+        $directiveId = 'DIR-2024-003';
+        $message = 'Directive is being processed';
+        $progress = 45;
+
+        $response = ResponseFormatterService::pending($directiveId, $message, $progress);
+
+        self::assertEqual($response['status'], ResponseFormatterService::STATUS_PENDING, 'Pending status');
+        self::assertEqual($response['directiveId'], $directiveId, 'Directive ID');
+        self::assertEqual($response['message'], $message, 'Status message');
+        self::assertEqual($response['progress'], $progress, 'Progress percentage');
+
+        // Test progress clamping
+        $responseHighProgress = ResponseFormatterService::pending($directiveId, $message, 150);
+        self::assertEqual($responseHighProgress['progress'], 100, 'Progress clamped to max 100');
+
+        $responseLowProgress = ResponseFormatterService::pending($directiveId, $message, -10);
+        self::assertEqual($responseLowProgress['progress'], 0, 'Progress clamped to min 0');
+
+        echo "\n";
+    }
+
+    /**
+     * Test validation error response
+     */
+    private static function testValidationErrorResponse(): void {
+        echo "Testing validation error response...\n";
+
+        $message = 'Invalid directive format';
+        $validationErrors = [
+            'subject' => 'Subject is required',
+            'priority' => 'Priority must be between 1 and 5'
+        ];
+
+        $response = ResponseFormatterService::validationError($message, $validationErrors, 'DIR-004');
+
+        self::assertEqual($response['status'], ResponseFormatterService::STATUS_ERROR, 'Error status');
+        self::assertEqual($response['error']['code'], ResponseFormatterService::ERROR_VALIDATION, 'Validation error code');
+        self::assertTrue(count($response['error']['suggestedNextSteps']) > 0, 'Has suggested next steps');
+        self::assertTrue(isset($response['validationErrors']), 'Has validation errors');
+
+        echo "\n";
+    }
+
+    /**
+     * Test not found response
+     */
+    private static function testNotFoundResponse(): void {
+        echo "Testing not found response...\n";
+
+        $response = ResponseFormatterService::notFound('directive', 'DIR-999');
+
+        self::assertEqual($response['status'], ResponseFormatterService::STATUS_ERROR, 'Error status');
+        self::assertEqual($response['error']['code'], ResponseFormatterService::ERROR_NOT_FOUND, 'Not found error code');
+        self::assertTrue(strpos($response['error']['message'], 'directive') !== false, 'Message mentions resource');
+        self::assertTrue(count($response['error']['suggestedNextSteps']) > 0, 'Has suggested next steps');
+
+        echo "\n";
+    }
+
+    /**
+     * Test JSON conversion
+     */
+    private static function testJsonConversion(): void {
+        echo "Testing JSON conversion...\n";
+
+        $response = ResponseFormatterService::success('DIR-005', 'Test message');
+        $json = ResponseFormatterService::toJson($response);
+
+        self::assertTrue(is_string($json), 'JSON is string');
+        self::assertTrue(json_decode($json) !== null, 'Valid JSON');
+
+        // Test pretty print
+        $prettyJson = ResponseFormatterService::toJson($response, true);
+        self::assertTrue(strpos($prettyJson, "\n") !== false, 'Pretty print has newlines');
+
+        echo "\n";
+    }
+
+    /**
+     * Test response validation
+     */
+    private static function testResponseValidation(): void {
+        echo "Testing response validation...\n";
+
+        // Valid success response
+        $validSuccess = ['version' => '1.0', 'status' => 'success', 'timestamp' => date('c'), 'message' => 'OK'];
+        self::assertTrue(ResponseFormatterService::isValidResponse($validSuccess), 'Valid success response');
+
+        // Valid error response
+        $validError = ['version' => '1.0', 'status' => 'error', 'timestamp' => date('c'), 'error' => ['code' => 'ERR', 'message' => 'Error']];
+        self::assertTrue(ResponseFormatterService::isValidResponse($validError), 'Valid error response');
+
+        // Invalid - missing required fields
+        $missingVersion = ['status' => 'success', 'timestamp' => date('c')];
+        self::assertFalse(ResponseFormatterService::isValidResponse($missingVersion), 'Invalid - missing version');
+
+        // Invalid - wrong status
+        $wrongStatus = ['version' => '1.0', 'status' => 'invalid', 'timestamp' => date('c')];
+        self::assertFalse(ResponseFormatterService::isValidResponse($wrongStatus), 'Invalid - wrong status');
+
+        // Invalid - success without message
+        $successNoMessage = ['version' => '1.0', 'status' => 'success', 'timestamp' => date('c')];
+        self::assertFalse(ResponseFormatterService::isValidResponse($successNoMessage), 'Invalid - success without message');
+
+        // Invalid - error without error details
+        $errorNoDetails = ['version' => '1.0', 'status' => 'error', 'timestamp' => date('c')];
+        self::assertFalse(ResponseFormatterService::isValidResponse($errorNoDetails), 'Invalid - error without details');
+
+        echo "\n";
+    }
+
+    /**
+     * Assert two values are equal
+     */
+    private static function assertEqual($actual, $expected, string $description): void {
+        if ($actual === $expected) {
+            self::$passed++;
+            echo "  [PASS] {$description}\n";
+        } else {
+            self::$failed++;
+            self::$errors[] = "{$description}: expected " . var_export($expected, true) . ", got " . var_export($actual, true);
+            echo "  [FAIL] {$description}\n";
+        }
+    }
+
+    /**
+     * Assert a condition is true
+     */
+    private static function assertTrue($condition, string $description): void {
+        if ($condition) {
+            self::$passed++;
+            echo "  [PASS] {$description}\n";
+        } else {
+            self::$failed++;
+            self::$errors[] = "{$description}: expected true";
+            echo "  [FAIL] {$description}\n";
+        }
+    }
+
+    /**
+     * Assert a condition is false
+     */
+    private static function assertFalse($condition, string $description): void {
+        if (!$condition) {
+            self::$passed++;
+            echo "  [PASS] {$description}\n";
+        } else {
+            self::$failed++;
+            self::$errors[] = "{$description}: expected false";
+            echo "  [FAIL] {$description}\n";
+        }
+    }
+
+    /**
+     * Assert timestamp is in ISO 8601 format
+     */
+    private static function assertTimestampFormat(string $timestamp, string $description): void {
+        $parsed = \DateTime::createFromFormat(\DateTime::ATOM, $timestamp);
+        if ($parsed !== false || preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/', $timestamp)) {
+            self::$passed++;
+            echo "  [PASS] {$description}\n";
+        } else {
+            self::$failed++;
+            self::$errors[] = "{$description}: '{$timestamp}' is not a valid ISO 8601 timestamp";
+            echo "  [FAIL] {$description}\n";
+        }
+    }
+
+    /**
+     * Print test results summary
+     */
+    private static function printResults(): void {
+        $total = self::$passed + self::$failed;
+        echo "\n=== Test Results ===\n";
+        echo "Passed: " . self::$passed . "/{$total}\n";
+        echo "Failed: " . self::$failed . "/{$total}\n";
+
+        if (!empty(self::$errors)) {
+            echo "\nErrors:\n";
+            foreach (self::$errors as $error) {
+                echo "  - {$error}\n";
+            }
+        }
+
+        if (self::$failed > 0) {
+            exit(1);
+        }
+    }
+}
+
+// Run tests if executed directly
+if (basename(__FILE__) === basename($_SERVER['PHP_SELF'] ?? '')) {
+    ResponseFormatterServiceTest::run();
+}


### PR DESCRIPTION
## Summary
- Implements ResponseFormatterService for generating consistent, structured responses to CEO directives
- Adds success, error, and pending response types with proper status indicators
- Includes JSON schema definition for response validation
- Adds unit tests covering all acceptance criteria (45 tests passing)

Closes #23

## Changes
- `services/ResponseFormatterService.php` - New response formatting service
- `tests/ResponseFormatterServiceTest.php` - Unit tests for the service

## Acceptance Criteria Verification

### Scenario 1 - Success Response
- Response contains success status
- Response contains ISO 8601 timestamp
- Response contains directive ID
- Response contains confirmation message

### Scenario 2 - Error Response
- Response contains error status
- Response contains error code
- Response contains descriptive message
- Response contains suggested next steps

### Scenario 3 - JSON Schema
- All responses follow predefined JSON schema with required fields
- Schema validation utility provided

## Test plan
- [x] Run unit tests: `php tests/ResponseFormatterServiceTest.php`
- [x] Verify all 45 tests pass
- [ ] Review code for adherence to project patterns
- [ ] Test integration with existing codebase