### PR TITLE
Add CEO directive logging system for audit trail

### DIFF
--- a/controls/Webhook.php
+++ b/controls/Webhook.php
@@ -15,6 +15,7 @@ use \app\services\EncryptionService;
 use \app\services\UserDatabaseService;
 use \app\services\MailgunService;
 use \app\services\TmuxService;
+use \app\services\CeoDirectiveLogger;
 
 require_once __DIR__ . '/../lib/Bean.php';
 require_once __DIR__ . '/../lib/plugins/AtlassianAuth.php';
@@ -24,8 +25,15 @@ require_once __DIR__ . '/../services/EncryptionService.php';
 require_once __DIR__ . '/../services/UserDatabaseService.php';
 require_once __DIR__ . '/../services/MailgunService.php';
 require_once __DIR__ . '/../services/TmuxService.php';
+require_once __DIR__ . '/../services/CeoDirectiveLogger.php';
 
 class Webhook extends BaseControls\Control {
+
+    /** @var string|null Current CEO directive ID for audit trail */
+    private ?string $currentDirectiveId = null;
+
+    /** @var CeoDirectiveLogger|null Current CEO directive logger instance */
+    private ?CeoDirectiveLogger $currentDirectiveLogger = null;
 
     /**
      * Handle Jira webhook
@@ -85,9 +93,30 @@ class Webhook extends BaseControls\Control {
 
         try {
             $this->processJiraWebhook($data);
+
+            // Log completion if we have a directive logger
+            if ($this->currentDirectiveLogger && $this->currentDirectiveId) {
+                $this->currentDirectiveLogger->logCompleted(
+                    $this->currentDirectiveId,
+                    'Jira webhook processed successfully',
+                    ['event' => $data['webhookEvent'] ?? 'unknown']
+                );
+            }
+
             echo json_encode(['success' => true]);
         } catch (\Exception $e) {
             $this->logger->error('Jira webhook processing failed', ['error' => $e->getMessage()]);
+
+            // Log error with full stack trace for audit trail
+            if ($this->currentDirectiveLogger && $this->currentDirectiveId) {
+                $this->currentDirectiveLogger->logError(
+                    $this->currentDirectiveId,
+                    'Webhook processing failed: ' . $e->getMessage(),
+                    $e,
+                    'Request failed with 500 error; manual review required'
+                );
+            }
+
             Flight::response()->status(500);
             echo json_encode(['error' => 'Processing failed']);
         }
@@ -188,6 +217,18 @@ class Webhook extends BaseControls\Control {
                 $this->logger->debug('Jira webhook: ignoring bot update', ['issue_key' => $issueKey]);
                 return;
             }
+
+            // Initialize CEO Directive Logger for audit trail
+            $directiveLogger = new CeoDirectiveLogger($memberId);
+            $directiveId = $directiveLogger->logDirectiveReceived($issueKey, 'jira', [
+                'event' => $event,
+                'cloud_id' => $cloudId,
+                'user' => $data['user']['displayName'] ?? 'unknown'
+            ]);
+
+            // Store directive ID for use in subsequent processing
+            $this->currentDirectiveId = $directiveId;
+            $this->currentDirectiveLogger = $directiveLogger;
         }
 
         // First, check if there's a local tmux session to augment
@@ -486,6 +527,16 @@ class Webhook extends BaseControls\Control {
             return;
         }
 
+        // Log processing step for CEO directive audit trail
+        if ($this->currentDirectiveLogger && $this->currentDirectiveId) {
+            $this->currentDirectiveLogger->logProcessingStep(
+                $this->currentDirectiveId,
+                'job_trigger',
+                'Triggering AI Developer job',
+                ['repo_id' => $repoId, 'tenant' => Flight::get('tenant.slug')]
+            );
+        }
+
         // Get tenant slug for multi-tenancy support
         $tenant = Flight::get('tenant.slug');
 
@@ -503,6 +554,20 @@ class Webhook extends BaseControls\Control {
                 'local' => $result['local'] ?? false,
                 'shard' => $result['shard'] ?? null
             ]);
+
+            // Log successful job trigger
+            if ($this->currentDirectiveLogger && $this->currentDirectiveId) {
+                $this->currentDirectiveLogger->logProcessingStep(
+                    $this->currentDirectiveId,
+                    'job_started',
+                    'AI Developer job started successfully',
+                    [
+                        'job_id' => $result['job_id'],
+                        'local' => $result['local'] ?? false,
+                        'shard' => $result['shard'] ?? null
+                    ]
+                );
+            }
         } else {
             $this->logger->warning('Failed to trigger AI Developer job via webhook', [
                 'member_id' => $memberId,
@@ -510,6 +575,17 @@ class Webhook extends BaseControls\Control {
                 'repo_id' => $repoId,
                 'error' => $result['error'] ?? 'Unknown error'
             ]);
+
+            // Log job trigger failure
+            if ($this->currentDirectiveLogger && $this->currentDirectiveId) {
+                $this->currentDirectiveLogger->logError(
+                    $this->currentDirectiveId,
+                    'Failed to trigger AI Developer job: ' . ($result['error'] ?? 'Unknown error'),
+                    null,
+                    'Will retry on next webhook or manual trigger',
+                    ['repo_id' => $repoId]
+                );
+            }
         }
     }
 

--- a/services/AIDevJobService.php
+++ b/services/AIDevJobService.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/AIDevStatusService.php';
 require_once __DIR__ . '/ShardRouter.php';
 require_once __DIR__ . '/ShopifyClient.php';
 require_once __DIR__ . '/TmuxService.php';
+require_once __DIR__ . '/CeoDirectiveLogger.php';
 require_once __DIR__ . '/../lib/plugins/AtlassianAuth.php';
 
 use \app\plugins\AtlassianAuth;
@@ -526,6 +527,14 @@ class AIDevJobService {
                 'pr_url' => $prUrl
             ]);
 
+            // Log the response for CEO directive audit trail
+            $this->logCeoDirectiveResponse(
+                $memberId,
+                $issueKey,
+                "PR #{$prNumber} created: {$prUrl}\nBranch: {$branchName}\nSummary: {$summary}",
+                CeoDirectiveLogger::DELIVERY_SUCCESS
+            );
+
             return true;
 
         } catch (\Exception $e) {
@@ -534,6 +543,15 @@ class AIDevJobService {
                 'issue_key' => $issueKey,
                 'error' => $e->getMessage()
             ]);
+
+            // Log the failed response attempt
+            $this->logCeoDirectiveResponse(
+                $memberId,
+                $issueKey,
+                'Failed to post PR summary: ' . $e->getMessage(),
+                CeoDirectiveLogger::DELIVERY_FAILED
+            );
+
             return false;
         }
     }
@@ -1034,11 +1052,29 @@ class AIDevJobService {
             // Post failure comment
             $this->postFailureComment($jiraClient, $issueKey, $errorMessage);
 
+            // Log CEO directive error for audit trail
+            $this->logCeoDirectiveError(
+                $memberId,
+                $issueKey,
+                $errorMessage,
+                null,
+                'Posted failure comment to Jira; ticket transitioned to failed status'
+            );
+
         } catch (\Exception $e) {
             $this->logger->error('Error in onJobFailed', [
                 'issue_key' => $issueKey,
                 'error' => $e->getMessage()
             ]);
+
+            // Log the secondary error
+            $this->logCeoDirectiveError(
+                $memberId,
+                $issueKey,
+                'Error during failure handling: ' . $e->getMessage(),
+                $e,
+                'Original error: ' . $errorMessage
+            );
         }
     }
 
@@ -1351,5 +1387,91 @@ class AIDevJobService {
         }
 
         return $settings;
+    }
+
+    // ========================================
+    // CEO Directive Logging Helpers
+    // ========================================
+
+    /**
+     * Log a CEO directive response for audit trail
+     * Creates a new directive entry if no active directive is found
+     *
+     * @param int $memberId Member ID
+     * @param string $issueKey Issue key
+     * @param string $responseContent Content of the response
+     * @param string $deliveryStatus Delivery status (success, failed, pending)
+     */
+    private function logCeoDirectiveResponse(int $memberId, string $issueKey, string $responseContent, string $deliveryStatus): void {
+        try {
+            $directiveLogger = new CeoDirectiveLogger($memberId);
+
+            // Try to find an existing directive for this issue from recent logs
+            $recentLogs = $directiveLogger->getLogsForIssue($issueKey, 1);
+            $directiveId = null;
+
+            if (!empty($recentLogs)) {
+                // Use the most recent directive ID for this issue
+                $directiveId = $recentLogs[0]['directive_id'];
+            } else {
+                // No existing directive found, create a new one
+                $directiveId = $directiveLogger->logDirectiveReceived($issueKey, 'system', [
+                    'source' => 'AIDevJobService',
+                    'action' => 'response_delivery'
+                ]);
+            }
+
+            $directiveLogger->logResponse($directiveId, $responseContent, $deliveryStatus, [
+                'delivery_method' => 'jira_comment',
+                'member_id' => $memberId
+            ]);
+
+        } catch (\Exception $e) {
+            // Don't let logging failures break the main flow
+            $this->logger->warning('Failed to log CEO directive response', [
+                'member_id' => $memberId,
+                'issue_key' => $issueKey,
+                'error' => $e->getMessage()
+            ]);
+        }
+    }
+
+    /**
+     * Log a CEO directive error for audit trail
+     *
+     * @param int $memberId Member ID
+     * @param string $issueKey Issue key
+     * @param string $errorMessage Error description
+     * @param \Throwable|null $exception Exception for stack trace
+     * @param string|null $recoveryAction Recovery action taken
+     */
+    public function logCeoDirectiveError(int $memberId, string $issueKey, string $errorMessage, ?\Throwable $exception = null, ?string $recoveryAction = null): void {
+        try {
+            $directiveLogger = new CeoDirectiveLogger($memberId);
+
+            // Try to find an existing directive for this issue
+            $recentLogs = $directiveLogger->getLogsForIssue($issueKey, 1);
+            $directiveId = null;
+
+            if (!empty($recentLogs)) {
+                $directiveId = $recentLogs[0]['directive_id'];
+            } else {
+                // No existing directive found, create a new one
+                $directiveId = $directiveLogger->logDirectiveReceived($issueKey, 'system', [
+                    'source' => 'AIDevJobService',
+                    'action' => 'error_logging'
+                ]);
+            }
+
+            $directiveLogger->logError($directiveId, $errorMessage, $exception, $recoveryAction);
+
+        } catch (\Exception $e) {
+            // Don't let logging failures break the main flow
+            $this->logger->warning('Failed to log CEO directive error', [
+                'member_id' => $memberId,
+                'issue_key' => $issueKey,
+                'error' => $e->getMessage()
+            ]);
+        }
     }
 }

--- a/services/CeoDirectiveLogger.php
+++ b/services/CeoDirectiveLogger.php
@@ -1,0 +1,476 @@
+<?php
+/**
+ * CEO Directive Logger Service
+ *
+ * Provides comprehensive logging for all CEO directive communications including:
+ * - Receipt of directives (from Jira/GitHub webhooks)
+ * - Processing status and steps
+ * - Error tracking with stack traces and recovery actions
+ * - Response delivery status
+ *
+ * Usage:
+ *   $logger = new CeoDirectiveLogger($memberId);
+ *   $directiveId = $logger->logDirectiveReceived($issueKey, 'jira', ['event' => 'issue_updated']);
+ *   $logger->logProcessingStep($directiveId, 'analyzing', 'Analyzing ticket requirements');
+ *   $logger->logResponse($directiveId, 'PR created successfully', 'success');
+ */
+
+namespace app\services;
+
+use \Flight as Flight;
+use \app\Bean;
+
+class CeoDirectiveLogger {
+
+    // Action constants for consistent logging
+    const ACTION_RECEIVED = 'received';
+    const ACTION_PROCESSING = 'processing';
+    const ACTION_COMPLETED = 'completed';
+    const ACTION_ERROR = 'error';
+    const ACTION_RESPONSE_SENT = 'response_sent';
+
+    // Delivery status constants
+    const DELIVERY_SUCCESS = 'success';
+    const DELIVERY_FAILED = 'failed';
+    const DELIVERY_PENDING = 'pending';
+
+    private int $memberId;
+    private $logger;
+
+    /**
+     * Constructor
+     *
+     * @param int $memberId Member ID for the current user/tenant
+     */
+    public function __construct(int $memberId) {
+        $this->memberId = $memberId;
+        $this->logger = Flight::get('log');
+    }
+
+    /**
+     * Generate a unique directive ID for grouping related log entries
+     *
+     * @return string Unique directive ID (32 character hex string)
+     */
+    public function generateDirectiveId(): string {
+        return bin2hex(random_bytes(16));
+    }
+
+    /**
+     * Log receipt of a CEO directive
+     *
+     * @param string $issueKey Jira/GitHub issue key (e.g., "SSI-1234" or "owner/repo#123")
+     * @param string $source Source of the directive ("jira", "github", "api")
+     * @param array $contextData Additional context data (event type, webhook data, etc.)
+     * @return string The generated directive ID for use in subsequent logs
+     */
+    public function logDirectiveReceived(string $issueKey, string $source, array $contextData = []): string {
+        $directiveId = $this->generateDirectiveId();
+
+        $message = sprintf(
+            'CEO directive received from %s for %s',
+            $source,
+            $issueKey
+        );
+
+        $context = array_merge($contextData, [
+            'source' => $source,
+            'timestamp' => date('Y-m-d H:i:s')
+        ]);
+
+        $this->createLogEntry(
+            $directiveId,
+            $issueKey,
+            self::ACTION_RECEIVED,
+            $message,
+            $context
+        );
+
+        // Also log to application logger for real-time monitoring
+        $this->logger->info($message, [
+            'directive_id' => $directiveId,
+            'member_id' => $this->memberId,
+            'issue_key' => $issueKey,
+            'source' => $source
+        ]);
+
+        return $directiveId;
+    }
+
+    /**
+     * Log a processing step in the directive lifecycle
+     *
+     * @param string $directiveId Directive ID from logDirectiveReceived()
+     * @param string $action Action being performed (e.g., "analyzing", "cloning", "implementing")
+     * @param string $message Human-readable message describing the step
+     * @param array $context Additional context data
+     */
+    public function logProcessingStep(string $directiveId, string $action, string $message, array $context = []): void {
+        // Get issue_key from previous log entry for this directive
+        $issueKey = $this->getIssueKeyForDirective($directiveId);
+
+        $this->createLogEntry(
+            $directiveId,
+            $issueKey,
+            self::ACTION_PROCESSING,
+            $message,
+            array_merge($context, ['step' => $action])
+        );
+
+        $this->logger->debug('CEO directive processing step', [
+            'directive_id' => $directiveId,
+            'member_id' => $this->memberId,
+            'action' => $action,
+            'message' => $message
+        ]);
+    }
+
+    /**
+     * Log completion of a directive
+     *
+     * @param string $directiveId Directive ID from logDirectiveReceived()
+     * @param string $message Completion message
+     * @param array $context Additional context data (e.g., PR URL, files changed)
+     */
+    public function logCompleted(string $directiveId, string $message, array $context = []): void {
+        $issueKey = $this->getIssueKeyForDirective($directiveId);
+
+        $this->createLogEntry(
+            $directiveId,
+            $issueKey,
+            self::ACTION_COMPLETED,
+            $message,
+            $context
+        );
+
+        $this->logger->info('CEO directive completed', [
+            'directive_id' => $directiveId,
+            'member_id' => $this->memberId,
+            'message' => $message
+        ]);
+    }
+
+    /**
+     * Log an error during directive processing
+     *
+     * @param string $directiveId Directive ID from logDirectiveReceived()
+     * @param string $errorMessage Error description
+     * @param \Throwable|null $exception Exception object for stack trace
+     * @param string|null $recoveryAction Description of recovery action taken
+     * @param array $context Additional context data
+     */
+    public function logError(
+        string $directiveId,
+        string $errorMessage,
+        ?\Throwable $exception = null,
+        ?string $recoveryAction = null,
+        array $context = []
+    ): void {
+        $issueKey = $this->getIssueKeyForDirective($directiveId);
+        $stackTrace = $exception ? $exception->getTraceAsString() : null;
+
+        // Include exception details in context
+        if ($exception) {
+            $context['exception_class'] = get_class($exception);
+            $context['exception_code'] = $exception->getCode();
+            $context['exception_file'] = $exception->getFile();
+            $context['exception_line'] = $exception->getLine();
+        }
+
+        $this->createLogEntry(
+            $directiveId,
+            $issueKey,
+            self::ACTION_ERROR,
+            $errorMessage,
+            $context,
+            $stackTrace,
+            $recoveryAction
+        );
+
+        $this->logger->error('CEO directive error', [
+            'directive_id' => $directiveId,
+            'member_id' => $this->memberId,
+            'error' => $errorMessage,
+            'recovery_action' => $recoveryAction,
+            'exception' => $exception ? $exception->getMessage() : null
+        ]);
+    }
+
+    /**
+     * Log a response sent back to the CEO (via Jira comment, GitHub comment, etc.)
+     *
+     * @param string $directiveId Directive ID from logDirectiveReceived()
+     * @param string $responseContent Content of the response sent
+     * @param string $deliveryStatus Delivery status (success, failed, pending)
+     * @param array $context Additional context data
+     */
+    public function logResponse(
+        string $directiveId,
+        string $responseContent,
+        string $deliveryStatus,
+        array $context = []
+    ): void {
+        $issueKey = $this->getIssueKeyForDirective($directiveId);
+
+        $message = sprintf(
+            'Response sent to %s with status: %s',
+            $issueKey,
+            $deliveryStatus
+        );
+
+        $this->createLogEntry(
+            $directiveId,
+            $issueKey,
+            self::ACTION_RESPONSE_SENT,
+            $message,
+            $context,
+            null,  // no stack trace
+            null,  // no recovery action
+            $responseContent,
+            $deliveryStatus
+        );
+
+        $logLevel = ($deliveryStatus === self::DELIVERY_SUCCESS) ? 'info' : 'warning';
+        $this->logger->$logLevel('CEO directive response sent', [
+            'directive_id' => $directiveId,
+            'member_id' => $this->memberId,
+            'delivery_status' => $deliveryStatus,
+            'response_length' => strlen($responseContent)
+        ]);
+    }
+
+    /**
+     * Retrieve all logs for a specific directive
+     *
+     * @param string $directiveId Directive ID
+     * @return array Array of log entries sorted by creation time
+     */
+    public function getDirectiveLogs(string $directiveId): array {
+        $logs = Bean::find(
+            'ceodirectivelogs',
+            'directive_id = ? ORDER BY created_at ASC',
+            [$directiveId]
+        );
+
+        $result = [];
+        foreach ($logs as $log) {
+            $result[] = $this->formatLogEntry($log);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Retrieve logs for a specific issue
+     *
+     * @param string $issueKey Issue key (Jira or GitHub)
+     * @param int|null $limit Maximum number of logs to return (null for all)
+     * @return array Array of log entries sorted by creation time descending
+     */
+    public function getLogsForIssue(string $issueKey, ?int $limit = null): array {
+        $sql = 'issue_key = ? AND member_id = ? ORDER BY created_at DESC';
+        $params = [$issueKey, $this->memberId];
+
+        if ($limit !== null) {
+            $sql .= ' LIMIT ' . (int)$limit;
+        }
+
+        $logs = Bean::find('ceodirectivelogs', $sql, $params);
+
+        $result = [];
+        foreach ($logs as $log) {
+            $result[] = $this->formatLogEntry($log);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get recent directive logs for the member
+     *
+     * @param int $limit Maximum number of logs to return
+     * @param string|null $action Filter by action type
+     * @return array Array of log entries
+     */
+    public function getRecentLogs(int $limit = 100, ?string $action = null): array {
+        $sql = 'member_id = ?';
+        $params = [$this->memberId];
+
+        if ($action !== null) {
+            $sql .= ' AND action = ?';
+            $params[] = $action;
+        }
+
+        $sql .= ' ORDER BY created_at DESC LIMIT ' . (int)$limit;
+
+        $logs = Bean::find('ceodirectivelogs', $sql, $params);
+
+        $result = [];
+        foreach ($logs as $log) {
+            $result[] = $this->formatLogEntry($log);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get error logs for a time period
+     *
+     * @param string $since DateTime string for the start of the period
+     * @return array Array of error log entries
+     */
+    public function getErrorLogsSince(string $since): array {
+        $logs = Bean::find(
+            'ceodirectivelogs',
+            'member_id = ? AND action = ? AND created_at >= ? ORDER BY created_at DESC',
+            [$this->memberId, self::ACTION_ERROR, $since]
+        );
+
+        $result = [];
+        foreach ($logs as $log) {
+            $result[] = $this->formatLogEntry($log);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the complete audit trail for a directive
+     * Includes timing information between steps
+     *
+     * @param string $directiveId Directive ID
+     * @return array Formatted audit trail with timing
+     */
+    public function getDirectiveAuditTrail(string $directiveId): array {
+        $logs = $this->getDirectiveLogs($directiveId);
+
+        if (empty($logs)) {
+            return [];
+        }
+
+        $trail = [];
+        $previousTime = null;
+
+        foreach ($logs as $log) {
+            $currentTime = strtotime($log['created_at']);
+            $entry = $log;
+
+            if ($previousTime !== null) {
+                $entry['time_since_previous'] = $currentTime - $previousTime;
+                $entry['time_since_previous_formatted'] = $this->formatDuration($currentTime - $previousTime);
+            } else {
+                $entry['time_since_previous'] = 0;
+                $entry['time_since_previous_formatted'] = '0s';
+            }
+
+            // Calculate total time from start
+            $startTime = strtotime($logs[0]['created_at']);
+            $entry['total_time'] = $currentTime - $startTime;
+            $entry['total_time_formatted'] = $this->formatDuration($currentTime - $startTime);
+
+            $trail[] = $entry;
+            $previousTime = $currentTime;
+        }
+
+        return $trail;
+    }
+
+    /**
+     * Create a log entry in the database
+     */
+    private function createLogEntry(
+        string $directiveId,
+        ?string $issueKey,
+        string $action,
+        string $message,
+        array $context = [],
+        ?string $stackTrace = null,
+        ?string $recoveryAction = null,
+        ?string $responseContent = null,
+        ?string $deliveryStatus = null
+    ): void {
+        try {
+            $log = Bean::dispense('ceodirectivelogs');
+            $log->directive_id = $directiveId;
+            $log->member_id = $this->memberId;
+            $log->issue_key = $issueKey;
+            $log->action = $action;
+            $log->message = $this->truncate($message, 4000);
+            $log->context_json = !empty($context) ? json_encode($context) : null;
+            $log->stack_trace = $stackTrace ? $this->truncate($stackTrace, 8000) : null;
+            $log->recovery_action = $recoveryAction ? $this->truncate($recoveryAction, 1000) : null;
+            $log->response_content = $responseContent ? $this->truncate($responseContent, 8000) : null;
+            $log->delivery_status = $deliveryStatus;
+            $log->created_at = date('Y-m-d H:i:s');
+
+            Bean::store($log);
+        } catch (\Exception $e) {
+            // Log to application logger if database write fails
+            $this->logger->error('Failed to write CEO directive log to database', [
+                'directive_id' => $directiveId,
+                'action' => $action,
+                'error' => $e->getMessage()
+            ]);
+        }
+    }
+
+    /**
+     * Get the issue key for a directive from existing logs
+     */
+    private function getIssueKeyForDirective(string $directiveId): ?string {
+        $log = Bean::findOne(
+            'ceodirectivelogs',
+            'directive_id = ? AND issue_key IS NOT NULL LIMIT 1',
+            [$directiveId]
+        );
+
+        return $log ? $log->issue_key : null;
+    }
+
+    /**
+     * Format a log bean into an array
+     */
+    private function formatLogEntry($log): array {
+        return [
+            'id' => (int)$log->id,
+            'directive_id' => $log->directive_id,
+            'member_id' => (int)$log->member_id,
+            'issue_key' => $log->issue_key,
+            'action' => $log->action,
+            'message' => $log->message,
+            'context' => $log->context_json ? json_decode($log->context_json, true) : [],
+            'stack_trace' => $log->stack_trace,
+            'recovery_action' => $log->recovery_action,
+            'response_content' => $log->response_content,
+            'delivery_status' => $log->delivery_status,
+            'created_at' => $log->created_at
+        ];
+    }
+
+    /**
+     * Truncate a string to maximum length
+     */
+    private function truncate(string $text, int $maxLength): string {
+        if (strlen($text) <= $maxLength) {
+            return $text;
+        }
+        return substr($text, 0, $maxLength - 15) . "\n... [truncated]";
+    }
+
+    /**
+     * Format a duration in seconds to a human-readable string
+     */
+    private function formatDuration(int $seconds): string {
+        if ($seconds < 60) {
+            return $seconds . 's';
+        }
+        if ($seconds < 3600) {
+            $minutes = floor($seconds / 60);
+            $secs = $seconds % 60;
+            return $minutes . 'm ' . $secs . 's';
+        }
+        $hours = floor($seconds / 3600);
+        $minutes = floor(($seconds % 3600) / 60);
+        return $hours . 'h ' . $minutes . 'm';
+    }
+}

--- a/sql/sqlite_schema.sql
+++ b/sql/sqlite_schema.sql
@@ -155,6 +155,20 @@ CREATE TABLE "usersettings" (
     value TEXT,
     updated_at TEXT DEFAULT CURRENT_TIMESTAMP
 );
+CREATE TABLE "ceodirectivelogs" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    directive_id TEXT NOT NULL,                    -- Unique identifier for grouping related logs
+    member_id INTEGER NOT NULL,                    -- User ID
+    issue_key TEXT,                                -- Jira/GitHub ticket reference
+    action TEXT NOT NULL,                          -- received, processing, completed, error, response_sent
+    message TEXT NOT NULL,                         -- Log message
+    context_json TEXT,                             -- JSON blob for additional data
+    stack_trace TEXT,                              -- For errors
+    recovery_action TEXT,                          -- For errors
+    response_content TEXT,                         -- For responses
+    delivery_status TEXT,                          -- For responses (success, failed, pending)
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
 -- Indexes
 CREATE INDEX idx_aidevjoblogs_issue ON aidevjoblogs(issue_key);
 CREATE INDEX idx_aidevjobs_board ON aidevjobs(board_id);
@@ -176,3 +190,8 @@ CREATE INDEX idx_aiagents_member ON "aiagents"(member_id);
 CREATE INDEX idx_aiagents_active ON "aiagents"(is_active);
 CREATE INDEX idx_aiagents_default ON "aiagents"(is_default);
 CREATE INDEX idx_repoconnections_agent ON "repoconnections"(agent_id);
+CREATE INDEX idx_ceodirectivelogs_directive ON "ceodirectivelogs"(directive_id);
+CREATE INDEX idx_ceodirectivelogs_member ON "ceodirectivelogs"(member_id);
+CREATE INDEX idx_ceodirectivelogs_issue ON "ceodirectivelogs"(issue_key);
+CREATE INDEX idx_ceodirectivelogs_action ON "ceodirectivelogs"(action);
+CREATE INDEX idx_ceodirectivelogs_created ON "ceodirectivelogs"(created_at DESC);


### PR DESCRIPTION
## Summary

Implements comprehensive logging for all CEO directive communications to provide a complete audit trail of interactions. This addresses the requirement in issue #25.

### Changes

- **New Service**: `CeoDirectiveLogger` - Provides structured logging for all directive communications
- **Database Schema**: Added `ceodirectivelogs` table to SQLite schema with proper indexes
- **Webhook Integration**: Integrated logging into the Jira webhook processing flow
- **AIDevJobService Integration**: Added logging for response delivery and error handling

### Files Changed

1. `sql/sqlite_schema.sql` - Added `ceodirectivelogs` table schema
2. `services/CeoDirectiveLogger.php` - New logging service (477 lines)
3. `controls/Webhook.php` - Integrated directive logging at webhook entry points
4. `services/AIDevJobService.php` - Added response and error logging

### Acceptance Criteria

**Scenario 1: Directive Received**
- When a CEO directive is received via Jira webhook, `logDirectiveReceived()` is called
- Each step is logged with timestamp, member ID, action taken, and outcome

**Scenario 2: Error Occurs**
- Errors are logged via `logError()` with full stack trace, context, and recovery actions
- Both webhook processing errors and job failures are captured

**Scenario 3: Response Sent**
- When responses are sent back (PR summary to Jira), `logResponse()` is called
- Response content and delivery status (success/failed) are logged

### Features

- Unique directive IDs for grouping related log entries
- Action constants for consistent logging (received, processing, completed, error, response_sent)
- Delivery status tracking (success, failed, pending)
- Audit trail retrieval with timing information between steps
- Error logs with full stack traces and recovery action documentation
- Application logger integration for real-time monitoring

Closes #25