### PR TITLE
feat: Add plugin repository sources management (Issue #99)

### DIFF
--- a/controls/Auth.php
+++ b/controls/Auth.php
@@ -965,6 +965,26 @@ HTML;
                 )
             ");
 
+            // Plugin Registry: Repository sources for plugin discovery
+            $userDb->exec("
+                CREATE TABLE IF NOT EXISTS pluginrepositorysource (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    member_id INTEGER,
+                    provider TEXT NOT NULL,
+                    repository_url TEXT NOT NULL,
+                    source_type TEXT DEFAULT 'repository',
+                    access_token TEXT,
+                    validation_status TEXT DEFAULT 'pending',
+                    validation_error TEXT,
+                    last_validated_at TEXT,
+                    is_active INTEGER DEFAULT 1,
+                    description TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT,
+                    UNIQUE(provider, repository_url, member_id)
+                )
+            ");
+
             // Enterprise indexes
             $userDb->exec("CREATE INDEX IF NOT EXISTS idx_repo_provider ON repoconnections(provider)");
             $userDb->exec("CREATE INDEX IF NOT EXISTS idx_repo_enabled ON repoconnections(enabled)");
@@ -973,6 +993,11 @@ HTML;
             $userDb->exec("CREATE INDEX IF NOT EXISTS idx_ai_job_issue ON aidevjobs(issue_key)");
             $userDb->exec("CREATE INDEX IF NOT EXISTS idx_ai_job_board ON aidevjobs(board_id)");
             $userDb->exec("CREATE INDEX IF NOT EXISTS idx_ai_log_job ON aidevjoblogs(job_id)");
+
+            // Plugin Registry indexes
+            $userDb->exec("CREATE INDEX IF NOT EXISTS idx_plugin_source_provider ON pluginrepositorysource(provider)");
+            $userDb->exec("CREATE INDEX IF NOT EXISTS idx_plugin_source_active ON pluginrepositorysource(is_active)");
+            $userDb->exec("CREATE INDEX IF NOT EXISTS idx_plugin_source_status ON pluginrepositorysource(validation_status)");
 
             $userDb->close();
 

--- a/controls/PluginSources.php
+++ b/controls/PluginSources.php
@@ -1,0 +1,315 @@
+<?php
+/**
+ * PluginSources Controller
+ * Manages plugin repository sources for plugin discovery
+ * Part of the Plugin Registry and Discovery epic
+ */
+
+namespace app;
+
+use \Flight as Flight;
+use \RedBeanPHP\R as R;
+use \Exception as Exception;
+use \app\services\PluginRepositoryService;
+
+require_once __DIR__ . '/../lib/Bean.php';
+require_once __DIR__ . '/../services/PluginRepositoryService.php';
+
+use \app\Bean;
+
+class PluginSources extends BaseControls\Control {
+
+    /**
+     * List all plugin repository sources
+     * GET /pluginsources
+     */
+    public function index() {
+        if (!$this->requireLogin()) return;
+
+        $memberId = $this->member->id;
+
+        // Get all sources for this member
+        $sources = Bean::findAll('pluginrepositorysource', 'member_id = ? ORDER BY created_at DESC', [$memberId]);
+
+        // Convert beans to array for view
+        $sourceList = [];
+        foreach ($sources as $source) {
+            $sourceList[] = [
+                'id' => $source->id,
+                'provider' => $source->provider,
+                'repository_url' => $source->repository_url,
+                'source_type' => $source->source_type,
+                'validation_status' => $source->validation_status,
+                'validation_error' => $source->validation_error,
+                'last_validated_at' => $source->last_validated_at,
+                'is_active' => (bool) $source->is_active,
+                'description' => $source->description,
+                'created_at' => $source->created_at,
+                'updated_at' => $source->updated_at
+            ];
+        }
+
+        $this->render('pluginsources/index', [
+            'title' => 'Plugin Repository Sources',
+            'sources' => $sourceList
+        ]);
+    }
+
+    /**
+     * Show form to add a new source
+     * GET /pluginsources/add
+     */
+    public function add() {
+        if (!$this->requireLogin()) return;
+
+        $this->render('pluginsources/add', [
+            'title' => 'Add Plugin Repository Source'
+        ]);
+    }
+
+    /**
+     * Store a new plugin repository source
+     * POST /pluginsources/store
+     */
+    public function store() {
+        if (!$this->requireLogin()) return;
+
+        if (Flight::request()->method !== 'POST') {
+            Flight::redirect('/pluginsources/add');
+            return;
+        }
+
+        if (!$this->validateCSRF()) return;
+
+        $memberId = $this->member->id;
+
+        // Get and validate input
+        $provider = $this->sanitize($this->getParam('provider'));
+        $repositoryUrl = $this->sanitize($this->getParam('repository_url'));
+        $sourceType = $this->sanitize($this->getParam('source_type')) ?: 'repository';
+        $accessToken = $this->getParam('access_token'); // Don't sanitize tokens
+        $description = $this->sanitize($this->getParam('description'));
+
+        // Validate required fields
+        if (empty($provider) || empty($repositoryUrl)) {
+            $this->flash('error', 'Provider and repository URL are required.');
+            Flight::redirect('/pluginsources/add');
+            return;
+        }
+
+        // Validate provider
+        $validProviders = ['github', 'gitlab', 'bitbucket', 'git'];
+        if (!in_array($provider, $validProviders)) {
+            $this->flash('error', 'Invalid provider. Supported providers: ' . implode(', ', $validProviders));
+            Flight::redirect('/pluginsources/add');
+            return;
+        }
+
+        // Check for duplicate
+        $existing = Bean::findOne('pluginrepositorysource',
+            'provider = ? AND repository_url = ? AND member_id = ?',
+            [$provider, $repositoryUrl, $memberId]
+        );
+
+        if ($existing) {
+            $this->flash('error', 'This repository source already exists.');
+            Flight::redirect('/pluginsources/add');
+            return;
+        }
+
+        try {
+            // Create new source
+            $source = Bean::dispense('pluginrepositorysource');
+            $source->member_id = $memberId;
+            $source->provider = $provider;
+            $source->repository_url = $repositoryUrl;
+            $source->source_type = $sourceType;
+            $source->description = $description;
+            $source->validation_status = 'pending';
+            $source->is_active = 1;
+            $source->created_at = date('Y-m-d H:i:s');
+
+            // Encrypt and store access token if provided
+            if (!empty($accessToken)) {
+                require_once __DIR__ . '/../services/EncryptionService.php';
+                $source->access_token = \app\services\EncryptionService::encrypt($accessToken);
+            }
+
+            Bean::store($source);
+
+            // Attempt initial validation
+            $service = new PluginRepositoryService();
+            $validationResult = $service->validateSource($source);
+
+            if ($validationResult['valid']) {
+                $source->validation_status = 'valid';
+                $source->validation_error = null;
+            } else {
+                $source->validation_status = 'error';
+                $source->validation_error = $validationResult['error'];
+            }
+            $source->last_validated_at = date('Y-m-d H:i:s');
+            $source->updated_at = date('Y-m-d H:i:s');
+            Bean::store($source);
+
+            $this->logger->info('Plugin repository source added', [
+                'member_id' => $memberId,
+                'provider' => $provider,
+                'repository_url' => $repositoryUrl,
+                'validation_status' => $source->validation_status
+            ]);
+
+            if ($validationResult['valid']) {
+                $this->flash('success', 'Plugin repository source added and validated successfully.');
+            } else {
+                $this->flash('warning', 'Plugin repository source added but validation failed: ' . $validationResult['error']);
+            }
+
+            Flight::redirect('/pluginsources');
+
+        } catch (Exception $e) {
+            $this->logger->error('Failed to add plugin repository source', ['error' => $e->getMessage()]);
+            $this->flash('error', 'Failed to add plugin repository source: ' . $e->getMessage());
+            Flight::redirect('/pluginsources/add');
+        }
+    }
+
+    /**
+     * Validate a plugin repository source
+     * POST /pluginsources/validate/{id}
+     */
+    public function validate($params = []) {
+        if (!$this->requireLogin()) return;
+
+        $sourceId = $params['operation']->name ?? 0;
+        $memberId = $this->member->id;
+
+        if (empty($sourceId)) {
+            Flight::jsonError('Source ID required', 400);
+            return;
+        }
+
+        // Load and verify ownership
+        $source = Bean::load('pluginrepositorysource', (int)$sourceId);
+        if (!$source->id || $source->member_id != $memberId) {
+            Flight::jsonError('Source not found', 404);
+            return;
+        }
+
+        try {
+            $service = new PluginRepositoryService();
+            $validationResult = $service->validateSource($source);
+
+            if ($validationResult['valid']) {
+                $source->validation_status = 'valid';
+                $source->validation_error = null;
+            } else {
+                $source->validation_status = 'error';
+                $source->validation_error = $validationResult['error'];
+            }
+            $source->last_validated_at = date('Y-m-d H:i:s');
+            $source->updated_at = date('Y-m-d H:i:s');
+            Bean::store($source);
+
+            $this->logger->info('Plugin repository source validated', [
+                'source_id' => $sourceId,
+                'validation_status' => $source->validation_status
+            ]);
+
+            Flight::jsonSuccess([
+                'validation_status' => $source->validation_status,
+                'validation_error' => $source->validation_error,
+                'last_validated_at' => $source->last_validated_at
+            ], $validationResult['valid'] ? 'Source validated successfully' : 'Validation failed');
+
+        } catch (Exception $e) {
+            $this->logger->error('Failed to validate plugin repository source', ['error' => $e->getMessage()]);
+            Flight::jsonError('Validation failed: ' . $e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * Delete a plugin repository source
+     * POST /pluginsources/delete/{id}
+     */
+    public function delete($params = []) {
+        if (!$this->requireLogin()) return;
+
+        $sourceId = $params['operation']->name ?? 0;
+        $memberId = $this->member->id;
+
+        if (empty($sourceId)) {
+            $this->flash('error', 'Source ID required');
+            Flight::redirect('/pluginsources');
+            return;
+        }
+
+        // Load and verify ownership
+        $source = Bean::load('pluginrepositorysource', (int)$sourceId);
+        if (!$source->id || $source->member_id != $memberId) {
+            $this->flash('error', 'Source not found');
+            Flight::redirect('/pluginsources');
+            return;
+        }
+
+        try {
+            $repositoryUrl = $source->repository_url;
+            Bean::trash($source);
+
+            $this->logger->info('Plugin repository source deleted', [
+                'member_id' => $memberId,
+                'source_id' => $sourceId,
+                'repository_url' => $repositoryUrl
+            ]);
+
+            $this->flash('success', 'Plugin repository source deleted successfully.');
+        } catch (Exception $e) {
+            $this->logger->error('Failed to delete plugin repository source', ['error' => $e->getMessage()]);
+            $this->flash('error', 'Failed to delete source: ' . $e->getMessage());
+        }
+
+        Flight::redirect('/pluginsources');
+    }
+
+    /**
+     * Toggle a plugin repository source active/inactive
+     * POST /pluginsources/toggle/{id}
+     */
+    public function toggle($params = []) {
+        if (!$this->requireLogin()) return;
+
+        $sourceId = $params['operation']->name ?? 0;
+        $memberId = $this->member->id;
+
+        if (empty($sourceId)) {
+            Flight::jsonError('Source ID required', 400);
+            return;
+        }
+
+        // Load and verify ownership
+        $source = Bean::load('pluginrepositorysource', (int)$sourceId);
+        if (!$source->id || $source->member_id != $memberId) {
+            Flight::jsonError('Source not found', 404);
+            return;
+        }
+
+        try {
+            $source->is_active = $source->is_active ? 0 : 1;
+            $source->updated_at = date('Y-m-d H:i:s');
+            Bean::store($source);
+
+            $this->logger->info('Plugin repository source toggled', [
+                'source_id' => $sourceId,
+                'is_active' => $source->is_active
+            ]);
+
+            Flight::jsonSuccess([
+                'is_active' => (bool) $source->is_active
+            ], $source->is_active ? 'Source enabled' : 'Source disabled');
+
+        } catch (Exception $e) {
+            $this->logger->error('Failed to toggle plugin repository source', ['error' => $e->getMessage()]);
+            Flight::jsonError('Failed to toggle source: ' . $e->getMessage(), 500);
+        }
+    }
+}

--- a/services/PluginRepositoryService.php
+++ b/services/PluginRepositoryService.php
@@ -1,0 +1,484 @@
+<?php
+/**
+ * PluginRepositoryService
+ * Handles validation and operations for plugin repository sources
+ * Part of the Plugin Registry and Discovery epic
+ */
+
+namespace app\services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use \Flight as Flight;
+
+class PluginRepositoryService {
+
+    private Client $client;
+
+    public function __construct() {
+        $this->client = new Client([
+            'timeout' => 15,
+            'verify' => true
+        ]);
+    }
+
+    /**
+     * Validate a plugin repository source
+     * Checks if the source is accessible and valid
+     *
+     * @param \RedBeanPHP\OODBBean $source The source bean to validate
+     * @return array ['valid' => bool, 'error' => string|null, 'details' => array]
+     */
+    public function validateSource($source): array {
+        $provider = $source->provider;
+        $repositoryUrl = $source->repository_url;
+        $accessToken = null;
+
+        // Decrypt access token if present
+        if (!empty($source->access_token)) {
+            require_once __DIR__ . '/EncryptionService.php';
+            try {
+                $accessToken = EncryptionService::decrypt($source->access_token);
+            } catch (\Exception $e) {
+                return [
+                    'valid' => false,
+                    'error' => 'Failed to decrypt access token',
+                    'details' => []
+                ];
+            }
+        }
+
+        switch ($provider) {
+            case 'github':
+                return $this->validateGitHubSource($repositoryUrl, $accessToken);
+            case 'gitlab':
+                return $this->validateGitLabSource($repositoryUrl, $accessToken);
+            case 'bitbucket':
+                return $this->validateBitbucketSource($repositoryUrl, $accessToken);
+            case 'git':
+                return $this->validateGenericGitSource($repositoryUrl, $accessToken);
+            default:
+                return [
+                    'valid' => false,
+                    'error' => 'Unsupported provider: ' . $provider,
+                    'details' => []
+                ];
+        }
+    }
+
+    /**
+     * Validate a GitHub repository or organization
+     *
+     * @param string $url Repository URL (owner/repo or organization name)
+     * @param string|null $token Access token for private repos
+     * @return array Validation result
+     */
+    public function validateGitHubSource(string $url, ?string $token = null): array {
+        $parsed = $this->parseRepositoryUrl($url);
+
+        if (!$parsed) {
+            return [
+                'valid' => false,
+                'error' => 'Invalid GitHub URL format. Use owner/repo or https://github.com/owner/repo',
+                'details' => []
+            ];
+        }
+
+        $headers = [
+            'Accept' => 'application/vnd.github+json',
+            'X-GitHub-Api-Version' => '2022-11-28',
+            'User-Agent' => 'MyCTOBot/1.0'
+        ];
+
+        if ($token) {
+            $headers['Authorization'] = 'Bearer ' . $token;
+        }
+
+        try {
+            // Check if it's an organization or a repository
+            $owner = $parsed['owner'];
+            $repo = $parsed['repo'] ?? null;
+
+            if ($repo) {
+                // Validate specific repository
+                $response = $this->client->get("https://api.github.com/repos/{$owner}/{$repo}", [
+                    'headers' => $headers
+                ]);
+                $data = json_decode($response->getBody()->getContents(), true);
+
+                return [
+                    'valid' => true,
+                    'error' => null,
+                    'details' => [
+                        'type' => 'repository',
+                        'name' => $data['full_name'],
+                        'description' => $data['description'] ?? '',
+                        'default_branch' => $data['default_branch'] ?? 'main',
+                        'private' => $data['private'] ?? false,
+                        'stars' => $data['stargazers_count'] ?? 0
+                    ]
+                ];
+            } else {
+                // Validate organization
+                $response = $this->client->get("https://api.github.com/orgs/{$owner}", [
+                    'headers' => $headers
+                ]);
+                $data = json_decode($response->getBody()->getContents(), true);
+
+                return [
+                    'valid' => true,
+                    'error' => null,
+                    'details' => [
+                        'type' => 'organization',
+                        'name' => $data['login'],
+                        'description' => $data['description'] ?? '',
+                        'public_repos' => $data['public_repos'] ?? 0
+                    ]
+                ];
+            }
+
+        } catch (GuzzleException $e) {
+            $statusCode = $e->getCode();
+            $errorMessage = $this->getGitHubErrorMessage($statusCode, $e->getMessage());
+
+            return [
+                'valid' => false,
+                'error' => $errorMessage,
+                'details' => ['status_code' => $statusCode]
+            ];
+        }
+    }
+
+    /**
+     * Validate a GitLab repository or group
+     *
+     * @param string $url Repository URL
+     * @param string|null $token Access token
+     * @return array Validation result
+     */
+    public function validateGitLabSource(string $url, ?string $token = null): array {
+        $parsed = $this->parseGitLabUrl($url);
+
+        if (!$parsed) {
+            return [
+                'valid' => false,
+                'error' => 'Invalid GitLab URL format',
+                'details' => []
+            ];
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+            'User-Agent' => 'MyCTOBot/1.0'
+        ];
+
+        if ($token) {
+            $headers['PRIVATE-TOKEN'] = $token;
+        }
+
+        try {
+            $baseUrl = $parsed['base_url'] ?? 'https://gitlab.com';
+            $projectPath = urlencode($parsed['path']);
+
+            $response = $this->client->get("{$baseUrl}/api/v4/projects/{$projectPath}", [
+                'headers' => $headers
+            ]);
+            $data = json_decode($response->getBody()->getContents(), true);
+
+            return [
+                'valid' => true,
+                'error' => null,
+                'details' => [
+                    'type' => 'repository',
+                    'name' => $data['path_with_namespace'],
+                    'description' => $data['description'] ?? '',
+                    'default_branch' => $data['default_branch'] ?? 'main',
+                    'visibility' => $data['visibility'] ?? 'private'
+                ]
+            ];
+
+        } catch (GuzzleException $e) {
+            return [
+                'valid' => false,
+                'error' => $this->getGenericErrorMessage($e->getCode(), $e->getMessage()),
+                'details' => ['status_code' => $e->getCode()]
+            ];
+        }
+    }
+
+    /**
+     * Validate a Bitbucket repository
+     *
+     * @param string $url Repository URL
+     * @param string|null $token Access token (app password)
+     * @return array Validation result
+     */
+    public function validateBitbucketSource(string $url, ?string $token = null): array {
+        $parsed = $this->parseRepositoryUrl($url);
+
+        if (!$parsed || empty($parsed['repo'])) {
+            return [
+                'valid' => false,
+                'error' => 'Invalid Bitbucket URL format. Use workspace/repo',
+                'details' => []
+            ];
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+            'User-Agent' => 'MyCTOBot/1.0'
+        ];
+
+        // Bitbucket uses Basic Auth with app passwords
+        $auth = null;
+        if ($token) {
+            // Token format should be "username:app_password"
+            $auth = explode(':', $token, 2);
+            if (count($auth) !== 2) {
+                return [
+                    'valid' => false,
+                    'error' => 'Invalid Bitbucket credentials format. Use username:app_password',
+                    'details' => []
+                ];
+            }
+        }
+
+        try {
+            $options = ['headers' => $headers];
+            if ($auth) {
+                $options['auth'] = $auth;
+            }
+
+            $workspace = $parsed['owner'];
+            $repo = $parsed['repo'];
+
+            $response = $this->client->get("https://api.bitbucket.org/2.0/repositories/{$workspace}/{$repo}", $options);
+            $data = json_decode($response->getBody()->getContents(), true);
+
+            return [
+                'valid' => true,
+                'error' => null,
+                'details' => [
+                    'type' => 'repository',
+                    'name' => $data['full_name'],
+                    'description' => $data['description'] ?? '',
+                    'is_private' => $data['is_private'] ?? false
+                ]
+            ];
+
+        } catch (GuzzleException $e) {
+            return [
+                'valid' => false,
+                'error' => $this->getGenericErrorMessage($e->getCode(), $e->getMessage()),
+                'details' => ['status_code' => $e->getCode()]
+            ];
+        }
+    }
+
+    /**
+     * Validate a generic Git repository (checks if accessible)
+     *
+     * @param string $url Git repository URL
+     * @param string|null $token Not used for generic git
+     * @return array Validation result
+     */
+    public function validateGenericGitSource(string $url, ?string $token = null): array {
+        // For generic git URLs, we can only do basic validation
+        // Full validation would require git ls-remote which needs shell access
+
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return [
+                'valid' => false,
+                'error' => 'Invalid URL format',
+                'details' => []
+            ];
+        }
+
+        // Check if URL ends with .git or looks like a git URL
+        if (!preg_match('/\.git$|git@|\/\/git\./', $url)) {
+            return [
+                'valid' => false,
+                'error' => 'URL does not appear to be a Git repository',
+                'details' => []
+            ];
+        }
+
+        // Try to make a HEAD request to check accessibility
+        try {
+            // Convert git:// to https:// for HTTP check
+            $httpUrl = preg_replace('/^git:\/\//', 'https://', $url);
+            $httpUrl = preg_replace('/^git@([^:]+):/', 'https://$1/', $httpUrl);
+
+            $this->client->head($httpUrl, [
+                'timeout' => 10,
+                'allow_redirects' => true
+            ]);
+
+            return [
+                'valid' => true,
+                'error' => null,
+                'details' => [
+                    'type' => 'repository',
+                    'name' => basename($url, '.git'),
+                    'note' => 'Basic URL check passed. Full validation requires git access.'
+                ]
+            ];
+
+        } catch (GuzzleException $e) {
+            // Not all git repos respond to HTTP HEAD, so treat timeout/connection errors differently
+            $code = $e->getCode();
+            if ($code >= 500 || $code === 0) {
+                return [
+                    'valid' => true,
+                    'error' => null,
+                    'details' => [
+                        'type' => 'repository',
+                        'name' => basename($url, '.git'),
+                        'note' => 'URL format valid. Server may require authentication.'
+                    ]
+                ];
+            }
+
+            return [
+                'valid' => false,
+                'error' => 'Repository not accessible: ' . $this->getGenericErrorMessage($code, $e->getMessage()),
+                'details' => ['status_code' => $code]
+            ];
+        }
+    }
+
+    /**
+     * Parse a repository URL to extract owner and repo
+     * Supports formats:
+     * - owner/repo
+     * - https://github.com/owner/repo
+     * - https://github.com/owner/repo.git
+     * - git@github.com:owner/repo.git
+     *
+     * @param string $url Repository URL or path
+     * @return array|null ['owner' => string, 'repo' => string|null]
+     */
+    public function parseRepositoryUrl(string $url): ?array {
+        $url = trim($url);
+
+        // Handle simple owner/repo format
+        if (preg_match('/^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)$/', $url, $matches)) {
+            return [
+                'owner' => $matches[1],
+                'repo' => rtrim($matches[2], '.git')
+            ];
+        }
+
+        // Handle simple owner format (organization)
+        if (preg_match('/^([a-zA-Z0-9_-]+)$/', $url, $matches)) {
+            return [
+                'owner' => $matches[1],
+                'repo' => null
+            ];
+        }
+
+        // Handle HTTPS URLs
+        if (preg_match('/https?:\/\/[^\/]+\/([a-zA-Z0-9_-]+)(?:\/([a-zA-Z0-9_.-]+))?/', $url, $matches)) {
+            return [
+                'owner' => $matches[1],
+                'repo' => isset($matches[2]) ? rtrim($matches[2], '.git') : null
+            ];
+        }
+
+        // Handle SSH URLs (git@github.com:owner/repo.git)
+        if (preg_match('/git@[^:]+:([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)/', $url, $matches)) {
+            return [
+                'owner' => $matches[1],
+                'repo' => rtrim($matches[2], '.git')
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse a GitLab URL to extract base URL and project path
+     *
+     * @param string $url GitLab URL
+     * @return array|null
+     */
+    private function parseGitLabUrl(string $url): ?array {
+        $url = trim($url);
+
+        // Handle gitlab.com URLs
+        if (preg_match('/https?:\/\/(gitlab\.com)\/(.+?)(?:\.git)?$/', $url, $matches)) {
+            return [
+                'base_url' => 'https://' . $matches[1],
+                'path' => rtrim($matches[2], '/')
+            ];
+        }
+
+        // Handle self-hosted GitLab URLs
+        if (preg_match('/https?:\/\/([^\/]+)\/(.+?)(?:\.git)?$/', $url, $matches)) {
+            return [
+                'base_url' => 'https://' . $matches[1],
+                'path' => rtrim($matches[2], '/')
+            ];
+        }
+
+        // Handle simple path format for gitlab.com
+        if (preg_match('/^([a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_.-]+)+)$/', $url, $matches)) {
+            return [
+                'base_url' => 'https://gitlab.com',
+                'path' => $matches[1]
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get a user-friendly error message for GitHub API errors
+     *
+     * @param int $statusCode HTTP status code
+     * @param string $rawMessage Raw error message
+     * @return string User-friendly error message
+     */
+    private function getGitHubErrorMessage(int $statusCode, string $rawMessage): string {
+        switch ($statusCode) {
+            case 401:
+                return 'Authentication failed. Please check your access token.';
+            case 403:
+                return 'Access forbidden. You may have hit the rate limit or lack permissions.';
+            case 404:
+                return 'Repository or organization not found. Please check the URL and ensure you have access.';
+            case 422:
+                return 'Invalid request. Please check the URL format.';
+            default:
+                if ($statusCode >= 500) {
+                    return 'GitHub API is currently unavailable. Please try again later.';
+                }
+                return 'Validation failed: ' . $rawMessage;
+        }
+    }
+
+    /**
+     * Get a generic user-friendly error message
+     *
+     * @param int $statusCode HTTP status code
+     * @param string $rawMessage Raw error message
+     * @return string User-friendly error message
+     */
+    private function getGenericErrorMessage(int $statusCode, string $rawMessage): string {
+        switch ($statusCode) {
+            case 401:
+                return 'Authentication required or failed.';
+            case 403:
+                return 'Access forbidden. Please check your permissions.';
+            case 404:
+                return 'Repository not found.';
+            case 0:
+                return 'Connection failed. Please check the URL.';
+            default:
+                if ($statusCode >= 500) {
+                    return 'Server error. Please try again later.';
+                }
+                return 'Validation failed (HTTP ' . $statusCode . ')';
+        }
+    }
+}

--- a/views/pluginsources/add.php
+++ b/views/pluginsources/add.php
@@ -1,0 +1,203 @@
+<div class="container py-4">
+    <nav aria-label="breadcrumb" class="mb-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/settings/connections">Settings</a></li>
+            <li class="breadcrumb-item"><a href="/pluginsources">Plugin Sources</a></li>
+            <li class="breadcrumb-item active">Add Source</li>
+        </ol>
+    </nav>
+
+    <div class="row">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Add Plugin Repository Source</h5>
+                </div>
+                <div class="card-body">
+                    <form method="POST" action="/pluginsources/store" id="addSourceForm">
+                        <?= $csrf['field'] ?? '' ?>
+
+                        <div class="mb-3">
+                            <label for="provider" class="form-label">Provider <span class="text-danger">*</span></label>
+                            <select class="form-select" id="provider" name="provider" required onchange="updatePlaceholder()">
+                                <option value="">Select a provider...</option>
+                                <option value="github">GitHub</option>
+                                <option value="gitlab">GitLab</option>
+                                <option value="bitbucket">Bitbucket</option>
+                                <option value="git">Generic Git</option>
+                            </select>
+                            <div class="form-text" id="provider-help">Select the Git hosting provider.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="repository_url" class="form-label">Repository URL <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="repository_url" name="repository_url"
+                                   placeholder="owner/repo or https://github.com/owner/repo" required>
+                            <div class="form-text" id="url-help">
+                                Enter the repository URL or path. Examples:
+                                <ul class="mb-0 mt-1">
+                                    <li><code>owner/repo</code> - A specific repository</li>
+                                    <li><code>organization</code> - An entire organization (GitHub only)</li>
+                                    <li><code>https://github.com/owner/repo</code> - Full URL</li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="source_type" class="form-label">Source Type</label>
+                            <select class="form-select" id="source_type" name="source_type">
+                                <option value="repository">Repository (single repo)</option>
+                                <option value="organization">Organization (scan all repos)</option>
+                            </select>
+                            <div class="form-text">Choose whether this is a single repository or an organization to scan.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="access_token" class="form-label">Access Token</label>
+                            <input type="password" class="form-control" id="access_token" name="access_token"
+                                   placeholder="Optional: For private repositories">
+                            <div class="form-text" id="token-help">
+                                Required for private repositories. Leave blank for public repos.
+                                <span id="token-format-help"></span>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="description" class="form-label">Description</label>
+                            <input type="text" class="form-control" id="description" name="description"
+                                   placeholder="Optional: Brief description of this source">
+                            <div class="form-text">A helpful note about what plugins this source contains.</div>
+                        </div>
+
+                        <div class="d-flex gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="bi bi-plus-lg"></i> Add Source
+                            </button>
+                            <a href="/pluginsources" class="btn btn-outline-secondary">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-4">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Provider Information</h5>
+                </div>
+                <div class="card-body">
+                    <div id="provider-info-github" class="provider-info d-none">
+                        <h6><i class="bi bi-github"></i> GitHub</h6>
+                        <p class="mb-2">Supports repositories and organizations.</p>
+                        <p class="mb-2"><strong>URL formats:</strong></p>
+                        <ul class="small">
+                            <li><code>owner/repo</code></li>
+                            <li><code>organization</code></li>
+                            <li><code>https://github.com/owner/repo</code></li>
+                        </ul>
+                        <p class="mb-0"><strong>Token:</strong> Personal Access Token with <code>repo</code> scope for private repos.</p>
+                    </div>
+
+                    <div id="provider-info-gitlab" class="provider-info d-none">
+                        <h6><i class="bi bi-gitlab"></i> GitLab</h6>
+                        <p class="mb-2">Supports repositories and groups.</p>
+                        <p class="mb-2"><strong>URL formats:</strong></p>
+                        <ul class="small">
+                            <li><code>group/project</code></li>
+                            <li><code>https://gitlab.com/group/project</code></li>
+                            <li>Self-hosted URLs supported</li>
+                        </ul>
+                        <p class="mb-0"><strong>Token:</strong> Personal Access Token with <code>read_api</code> scope.</p>
+                    </div>
+
+                    <div id="provider-info-bitbucket" class="provider-info d-none">
+                        <h6><i class="bi bi-bucket"></i> Bitbucket</h6>
+                        <p class="mb-2">Supports repositories.</p>
+                        <p class="mb-2"><strong>URL formats:</strong></p>
+                        <ul class="small">
+                            <li><code>workspace/repo</code></li>
+                            <li><code>https://bitbucket.org/workspace/repo</code></li>
+                        </ul>
+                        <p class="mb-0"><strong>Token:</strong> App password in format <code>username:app_password</code></p>
+                    </div>
+
+                    <div id="provider-info-git" class="provider-info d-none">
+                        <h6><i class="bi bi-git"></i> Generic Git</h6>
+                        <p class="mb-2">Any Git repository accessible via URL.</p>
+                        <p class="mb-2"><strong>URL formats:</strong></p>
+                        <ul class="small">
+                            <li><code>https://example.com/repo.git</code></li>
+                            <li><code>git://example.com/repo.git</code></li>
+                        </ul>
+                        <p class="mb-0"><strong>Note:</strong> Authentication may not be supported for all Git servers.</p>
+                    </div>
+
+                    <div id="provider-info-default" class="provider-info">
+                        <p class="text-muted mb-0">Select a provider to see specific instructions.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card mt-4">
+                <div class="card-header">
+                    <h5 class="card-title mb-0">Tips</h5>
+                </div>
+                <div class="card-body">
+                    <ul class="mb-0 small">
+                        <li class="mb-2">Start with public repositories - no token needed</li>
+                        <li class="mb-2">For organizations, only public repos are scanned unless a token is provided</li>
+                        <li class="mb-2">Tokens are encrypted before storage</li>
+                        <li>The source will be validated automatically after creation</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function updatePlaceholder() {
+    const provider = document.getElementById('provider').value;
+    const urlInput = document.getElementById('repository_url');
+    const tokenHelp = document.getElementById('token-format-help');
+
+    // Hide all provider info cards
+    document.querySelectorAll('.provider-info').forEach(el => el.classList.add('d-none'));
+
+    // Show relevant provider info
+    if (provider) {
+        const infoEl = document.getElementById('provider-info-' + provider);
+        if (infoEl) {
+            infoEl.classList.remove('d-none');
+        }
+    } else {
+        document.getElementById('provider-info-default').classList.remove('d-none');
+    }
+
+    // Update placeholder and help text based on provider
+    switch (provider) {
+        case 'github':
+            urlInput.placeholder = 'owner/repo or organization';
+            tokenHelp.textContent = 'Create at: Settings > Developer settings > Personal access tokens';
+            break;
+        case 'gitlab':
+            urlInput.placeholder = 'group/project or full URL';
+            tokenHelp.textContent = 'Create at: User Settings > Access Tokens';
+            break;
+        case 'bitbucket':
+            urlInput.placeholder = 'workspace/repo';
+            tokenHelp.textContent = 'Format: username:app_password';
+            break;
+        case 'git':
+            urlInput.placeholder = 'https://example.com/repo.git';
+            tokenHelp.textContent = '';
+            break;
+        default:
+            urlInput.placeholder = 'owner/repo or https://github.com/owner/repo';
+            tokenHelp.textContent = '';
+    }
+}
+
+// Initialize on page load
+document.addEventListener('DOMContentLoaded', updatePlaceholder);
+</script>

--- a/views/pluginsources/index.php
+++ b/views/pluginsources/index.php
@@ -1,0 +1,255 @@
+<div class="container py-4">
+    <nav aria-label="breadcrumb" class="mb-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/settings/connections">Settings</a></li>
+            <li class="breadcrumb-item active">Plugin Repository Sources</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h1 class="h2 mb-1">Plugin Repository Sources</h1>
+            <p class="text-muted mb-0">Configure where the system searches for plugins</p>
+        </div>
+        <a href="/pluginsources/add" class="btn btn-primary">
+            <i class="bi bi-plus-lg"></i> Add Source
+        </a>
+    </div>
+
+    <?php if (empty($sources)): ?>
+    <div class="card">
+        <div class="card-body text-center py-5">
+            <i class="bi bi-folder2-open display-4 text-muted mb-3"></i>
+            <h5 class="text-muted">No Repository Sources Configured</h5>
+            <p class="text-muted mb-4">Add plugin repository sources to enable plugin discovery.</p>
+            <a href="/pluginsources/add" class="btn btn-primary">
+                <i class="bi bi-plus-lg"></i> Add Your First Source
+            </a>
+        </div>
+    </div>
+    <?php else: ?>
+    <div class="card">
+        <div class="card-header">
+            <h5 class="card-title mb-0">Configured Sources</h5>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Provider</th>
+                        <th>Repository URL</th>
+                        <th>Type</th>
+                        <th>Status</th>
+                        <th>Last Validated</th>
+                        <th style="width: 200px;">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($sources as $source): ?>
+                    <tr id="source-row-<?= $source['id'] ?>">
+                        <td>
+                            <span class="badge bg-secondary">
+                                <?php
+                                $providerIcons = [
+                                    'github' => 'bi-github',
+                                    'gitlab' => 'bi-gitlab',
+                                    'bitbucket' => 'bi-bucket',
+                                    'git' => 'bi-git'
+                                ];
+                                $icon = $providerIcons[$source['provider']] ?? 'bi-git';
+                                ?>
+                                <i class="bi <?= $icon ?>"></i>
+                                <?= htmlspecialchars(ucfirst($source['provider'])) ?>
+                            </span>
+                        </td>
+                        <td>
+                            <code><?= htmlspecialchars($source['repository_url']) ?></code>
+                            <?php if (!empty($source['description'])): ?>
+                            <br><small class="text-muted"><?= htmlspecialchars($source['description']) ?></small>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <span class="text-muted"><?= htmlspecialchars(ucfirst($source['source_type'])) ?></span>
+                        </td>
+                        <td>
+                            <?php
+                            $statusBadges = [
+                                'pending' => 'bg-warning text-dark',
+                                'valid' => 'bg-success',
+                                'error' => 'bg-danger'
+                            ];
+                            $statusClass = $statusBadges[$source['validation_status']] ?? 'bg-secondary';
+                            ?>
+                            <span class="badge <?= $statusClass ?>" id="status-badge-<?= $source['id'] ?>">
+                                <?= htmlspecialchars(ucfirst($source['validation_status'])) ?>
+                            </span>
+                            <?php if ($source['validation_status'] === 'error' && !empty($source['validation_error'])): ?>
+                            <br><small class="text-danger" id="validation-error-<?= $source['id'] ?>"><?= htmlspecialchars($source['validation_error']) ?></small>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <?php if (!empty($source['last_validated_at'])): ?>
+                            <small class="text-muted" id="last-validated-<?= $source['id'] ?>"><?= htmlspecialchars($source['last_validated_at']) ?></small>
+                            <?php else: ?>
+                            <small class="text-muted">Never</small>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <div class="btn-group btn-group-sm">
+                                <button type="button" class="btn btn-outline-primary" onclick="validateSource(<?= $source['id'] ?>)" title="Validate">
+                                    <i class="bi bi-check-circle"></i>
+                                </button>
+                                <button type="button" class="btn btn-outline-<?= $source['is_active'] ? 'warning' : 'success' ?>"
+                                        onclick="toggleSource(<?= $source['id'] ?>)"
+                                        title="<?= $source['is_active'] ? 'Disable' : 'Enable' ?>"
+                                        id="toggle-btn-<?= $source['id'] ?>">
+                                    <i class="bi bi-<?= $source['is_active'] ? 'pause' : 'play' ?>"></i>
+                                </button>
+                                <a href="/pluginsources/delete/<?= $source['id'] ?>"
+                                   class="btn btn-outline-danger"
+                                   onclick="return confirm('Are you sure you want to delete this source?')"
+                                   title="Delete">
+                                    <i class="bi bi-trash"></i>
+                                </a>
+                            </div>
+                            <?php if (!$source['is_active']): ?>
+                            <br><small class="text-warning" id="inactive-label-<?= $source['id'] ?>">Inactive</small>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <div class="card mt-4">
+        <div class="card-header">
+            <h5 class="card-title mb-0">About Plugin Sources</h5>
+        </div>
+        <div class="card-body">
+            <p class="mb-3">Plugin repository sources define where the system searches for plugins. You can add:</p>
+            <ul class="mb-0">
+                <li><strong>GitHub repositories or organizations</strong> - Individual repos or entire orgs to scan for plugins</li>
+                <li><strong>GitLab repositories or groups</strong> - Single repos or group namespaces</li>
+                <li><strong>Bitbucket repositories</strong> - Workspace/repository combinations</li>
+                <li><strong>Generic Git URLs</strong> - Any Git repository accessible via URL</li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<script>
+function validateSource(sourceId) {
+    const btn = event.target.closest('button');
+    const originalHtml = btn.innerHTML;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+    btn.disabled = true;
+
+    fetch('/pluginsources/validate/' + sourceId, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content || ''
+        }
+    })
+    .then(response => response.json())
+    .then(data => {
+        btn.innerHTML = originalHtml;
+        btn.disabled = false;
+
+        if (data.success) {
+            // Update status badge
+            const badge = document.getElementById('status-badge-' + sourceId);
+            if (badge) {
+                const status = data.data.validation_status;
+                badge.className = 'badge ' + (status === 'valid' ? 'bg-success' : status === 'error' ? 'bg-danger' : 'bg-warning text-dark');
+                badge.textContent = status.charAt(0).toUpperCase() + status.slice(1);
+            }
+
+            // Update validation error
+            let errorEl = document.getElementById('validation-error-' + sourceId);
+            if (data.data.validation_error) {
+                if (!errorEl) {
+                    errorEl = document.createElement('small');
+                    errorEl.id = 'validation-error-' + sourceId;
+                    errorEl.className = 'text-danger';
+                    badge.parentNode.appendChild(document.createElement('br'));
+                    badge.parentNode.appendChild(errorEl);
+                }
+                errorEl.textContent = data.data.validation_error;
+            } else if (errorEl) {
+                errorEl.remove();
+            }
+
+            // Update last validated
+            const lastValidated = document.getElementById('last-validated-' + sourceId);
+            if (lastValidated && data.data.last_validated_at) {
+                lastValidated.textContent = data.data.last_validated_at;
+            }
+
+            alert(data.message);
+        } else {
+            alert('Error: ' + (data.error || 'Unknown error'));
+        }
+    })
+    .catch(error => {
+        btn.innerHTML = originalHtml;
+        btn.disabled = false;
+        alert('Request failed: ' + error.message);
+    });
+}
+
+function toggleSource(sourceId) {
+    const btn = document.getElementById('toggle-btn-' + sourceId);
+    const originalHtml = btn.innerHTML;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+    btn.disabled = true;
+
+    fetch('/pluginsources/toggle/' + sourceId, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content || ''
+        }
+    })
+    .then(response => response.json())
+    .then(data => {
+        btn.disabled = false;
+
+        if (data.success) {
+            const isActive = data.data.is_active;
+            btn.innerHTML = '<i class="bi bi-' + (isActive ? 'pause' : 'play') + '"></i>';
+            btn.className = 'btn btn-outline-' + (isActive ? 'warning' : 'success');
+            btn.title = isActive ? 'Disable' : 'Enable';
+
+            // Update inactive label
+            let label = document.getElementById('inactive-label-' + sourceId);
+            if (!isActive && !label) {
+                const td = btn.closest('td');
+                td.appendChild(document.createElement('br'));
+                label = document.createElement('small');
+                label.id = 'inactive-label-' + sourceId;
+                label.className = 'text-warning';
+                label.textContent = 'Inactive';
+                td.appendChild(label);
+            } else if (isActive && label) {
+                // Remove the br before the label too
+                if (label.previousSibling && label.previousSibling.nodeName === 'BR') {
+                    label.previousSibling.remove();
+                }
+                label.remove();
+            }
+        } else {
+            btn.innerHTML = originalHtml;
+            alert('Error: ' + (data.error || 'Unknown error'));
+        }
+    })
+    .catch(error => {
+        btn.innerHTML = originalHtml;
+        btn.disabled = false;
+        alert('Request failed: ' + error.message);
+    });
+}
+</script>


### PR DESCRIPTION
## Summary
- Implements plugin repository sources feature for configuring where the system searches for plugins
- Adds database schema for `pluginrepositorysource` table with support for GitHub, GitLab, Bitbucket, and generic Git providers
- Creates full CRUD controller with validation, toggle active/inactive, and delete functionality
- Includes service layer for validating repository accessibility using provider-specific APIs
- Provides Bootstrap 5 UI with status badges, inline validation, and provider-specific help

## Acceptance Criteria
- [x] System administrators can add a new GitHub repository source with valid credentials, and the source is saved and validated successfully
- [x] Users can view the sources list showing all configured sources with their status (active/inactive/error)
- [x] When validating an invalid or inaccessible source, users receive a clear error message explaining the issue

## Files Changed
- `controls/Auth.php` - Added pluginrepositorysource table schema to user database
- `controls/PluginSources.php` - New controller with index, add, store, validate, delete, toggle methods
- `services/PluginRepositoryService.php` - New service for source validation with provider-specific handlers
- `views/pluginsources/index.php` - List view with status badges and action buttons
- `views/pluginsources/add.php` - Form to add new sources with provider-specific instructions

## Test Plan
- [ ] Navigate to `/pluginsources` and verify empty state is displayed
- [ ] Click "Add Source" and verify form loads with provider dropdown
- [ ] Add a public GitHub repository (e.g., `octocat/hello-world`) and verify validation passes
- [ ] Add an invalid repository URL and verify error message is displayed
- [ ] Toggle a source inactive and verify status changes
- [ ] Delete a source and verify it is removed from the list
- [ ] Validate an existing source using the validate button

Closes #99