### PR TITLE
Add plugin registry cache management for issue #106

### DIFF
--- a/conf/config.example.ini
+++ b/conf/config.example.ini
@@ -232,6 +232,24 @@ webhook_secret = ""
 db_user = ""
 db_pass = ""
 
+[plugin_registry]
+; Plugin Registry Cache Settings
+; Used for caching and refreshing plugin metadata from configured sources
+
+; Refresh interval in seconds (default: 3600 = 1 hour)
+; The cache will automatically refresh when this TTL expires
+; Set to 0 to disable automatic refresh (manual refresh only)
+refresh_interval = 3600
+
+; Plugin sources (comma-separated list of directories or URLs)
+; Local directories: Relative paths from project root or absolute paths
+; Remote URLs: Must return JSON with plugin manifests
+; Examples:
+;   sources = "plugins,vendor/plugins"
+;   sources = "plugins,https://api.example.com/plugins.json"
+;   sources = "/var/www/shared-plugins"
+sources = "plugins"
+
 [shopify]
 ; Shopify App Settings for Enterprise tier
 ; Create at: https://partners.shopify.com/ > Apps > Create App

--- a/controls/Admin.php
+++ b/controls/Admin.php
@@ -894,4 +894,128 @@ class Admin extends Control {
         ]);
     }
 
+    // ========================================
+    // Plugin Registry Cache Management
+    // ========================================
+
+    /**
+     * Plugin registry cache management page
+     */
+    public function plugincache($params = []) {
+        // Check admin permission
+        if (!$this->requireLevel(self::ADMIN_LEVEL)) {
+            return;
+        }
+
+        // Handle cache actions
+        if ($this->getParam('action')) {
+            $action = $this->getParam('action');
+
+            switch ($action) {
+                case 'refresh':
+                    // Force refresh the plugin cache
+                    $result = \app\PluginRegistryCache::refresh(true);
+
+                    if ($result['success']) {
+                        $this->flash('success', "Plugin cache refreshed successfully. Found {$result['count']} plugins.");
+                    } else {
+                        $errorCount = count($result['errors']);
+                        $this->flash('warning', "Plugin cache refreshed with {$errorCount} error(s). Found {$result['count']} plugins.");
+                    }
+
+                    $this->logger->info('Plugin cache manually refreshed', [
+                        'admin_id' => $this->member->id,
+                        'plugins_count' => $result['count'],
+                        'errors' => $result['errors']
+                    ]);
+
+                    Flight::redirect('/admin/plugincache');
+                    return;
+
+                case 'invalidate':
+                    // Clear the plugin cache
+                    \app\PluginRegistryCache::invalidate();
+                    $this->flash('success', 'Plugin cache invalidated successfully');
+
+                    $this->logger->info('Plugin cache invalidated', [
+                        'admin_id' => $this->member->id
+                    ]);
+
+                    Flight::redirect('/admin/plugincache');
+                    return;
+
+                case 'warmup':
+                    // Warm up the cache
+                    $stats = \app\PluginRegistryCache::warmup();
+                    $this->flash('success', "Plugin cache warmed up with {$stats['count']} plugins");
+
+                    $this->logger->info('Plugin cache warmed up', [
+                        'admin_id' => $this->member->id,
+                        'stats' => $stats
+                    ]);
+
+                    Flight::redirect('/admin/plugincache');
+                    return;
+            }
+        }
+
+        // Get cache statistics and data for display
+        $this->viewData['title'] = 'Plugin Registry Cache';
+        $this->viewData['cache_stats'] = \app\PluginRegistryCache::getStats();
+        $this->viewData['plugins'] = \app\PluginRegistryCache::getPlugins();
+        $this->viewData['errors'] = \app\PluginRegistryCache::getRefreshErrors();
+
+        // Get configured sources for display
+        $sourcesConfig = Flight::get('plugin_registry.sources') ?? '';
+        $this->viewData['sources'] = array_filter(array_map('trim', explode(',', $sourcesConfig)));
+
+        $this->render('admin/plugin-cache', $this->viewData);
+    }
+
+    /**
+     * API endpoint for plugin cache refresh (for AJAX calls)
+     */
+    public function refreshplugincache($params = []) {
+        // Check admin permission
+        if (!$this->requireLevel(self::ADMIN_LEVEL)) {
+            return;
+        }
+
+        $force = $this->getParam('force', false);
+
+        $result = \app\PluginRegistryCache::refresh((bool)$force);
+
+        $this->logger->info('Plugin cache refresh requested via API', [
+            'admin_id' => $this->member->id,
+            'force' => $force,
+            'result' => $result
+        ]);
+
+        $this->json([
+            'success' => $result['success'],
+            'data' => [
+                'count' => $result['count'],
+                'errors' => $result['errors'],
+                'duration_ms' => $result['duration_ms'] ?? null,
+                'skipped' => $result['skipped'] ?? false,
+                'reason' => $result['reason'] ?? null
+            ]
+        ]);
+    }
+
+    /**
+     * API endpoint for plugin cache statistics
+     */
+    public function plugincachestats($params = []) {
+        // Check admin permission
+        if (!$this->requireLevel(self::ADMIN_LEVEL)) {
+            return;
+        }
+
+        $this->json([
+            'success' => true,
+            'data' => \app\PluginRegistryCache::getStats()
+        ]);
+    }
+
 }

--- a/lib/PluginRegistryCache.php
+++ b/lib/PluginRegistryCache.php
@@ -1,0 +1,725 @@
+<?php
+/**
+ * Plugin Registry Cache with APCu Support
+ * Provides high-performance plugin metadata caching with shared memory
+ * Falls back to per-request caching if APCu is not available
+ *
+ * Features:
+ * - Multi-tenant support via tenant-specific cache keys
+ * - Automatic TTL-based refresh
+ * - Source error preservation (keeps cached data on source failure)
+ * - Manual refresh capability for administrators
+ */
+
+namespace app;
+
+use \Flight as Flight;
+
+class PluginRegistryCache {
+
+    // Process-local cache (fastest access)
+    private static $localCache = null;
+
+    // Cache configuration - Use unique keys per installation/tenant
+    private static $CACHE_KEY = null;
+    private static $STATS_KEY = null;
+    private static $ERRORS_KEY = null;
+    private static $CACHE_VERSION_FILE = null;
+
+    // Default TTL: 1 hour (can be overridden by config)
+    private const DEFAULT_TTL = 3600;
+
+    /**
+     * Get cache directory path
+     */
+    private static function getCacheDir() {
+        $cacheDir = dirname(__DIR__) . '/cache';
+        if (!is_dir($cacheDir)) {
+            @mkdir($cacheDir, 0755, true);
+        }
+        return $cacheDir;
+    }
+
+    /**
+     * Get cache version file path
+     */
+    private static function getCacheVersionFile() {
+        if (self::$CACHE_VERSION_FILE === null) {
+            $cacheDir = self::getCacheDir();
+            $tenantSlug = self::getTenantSlug();
+            self::$CACHE_VERSION_FILE = $cacheDir . "/.plugin_cache_version_{$tenantSlug}";
+        }
+        return self::$CACHE_VERSION_FILE;
+    }
+
+    /**
+     * Get current tenant slug for multi-tenancy support
+     */
+    private static function getTenantSlug() {
+        return $_SESSION['tenant_slug'] ?? 'default';
+    }
+
+    /**
+     * Get current cache version (timestamp from version file)
+     */
+    private static function getCacheVersion() {
+        $versionFile = self::getCacheVersionFile();
+        if (file_exists($versionFile)) {
+            return (int)file_get_contents($versionFile);
+        }
+        return 0;
+    }
+
+    /**
+     * Get configured TTL in seconds
+     */
+    private static function getTTL() {
+        try {
+            $configTtl = Flight::get('plugin_registry.refresh_interval');
+            return $configTtl ? (int)$configTtl : self::DEFAULT_TTL;
+        } catch (\Exception $e) {
+            return self::DEFAULT_TTL;
+        }
+    }
+
+    /**
+     * Get unique cache key for this installation/tenant (includes version for cache busting)
+     */
+    private static function getCacheKey() {
+        if (self::$CACHE_KEY === null) {
+            // Create unique key based on installation path, tenant, and version
+            $tenantSlug = self::getTenantSlug();
+            $siteId = md5(__DIR__ . '_' . ($_SERVER['HTTP_HOST'] ?? 'cli') . '_' . $tenantSlug);
+            $version = self::getCacheVersion();
+            self::$CACHE_KEY = "myctobot_{$siteId}_plugins_v{$version}";
+            self::$STATS_KEY = "myctobot_{$siteId}_plugin_stats";
+            self::$ERRORS_KEY = "myctobot_{$siteId}_plugin_errors";
+        }
+        return self::$CACHE_KEY;
+    }
+
+    /**
+     * Get stats cache key
+     */
+    private static function getStatsKey() {
+        if (self::$STATS_KEY === null) {
+            self::getCacheKey(); // Initialize all keys
+        }
+        return self::$STATS_KEY;
+    }
+
+    /**
+     * Get errors cache key
+     */
+    private static function getErrorsKey() {
+        if (self::$ERRORS_KEY === null) {
+            self::getCacheKey(); // Initialize all keys
+        }
+        return self::$ERRORS_KEY;
+    }
+
+    /**
+     * Get cached plugin list
+     *
+     * @return array Array of plugin metadata
+     */
+    public static function getPlugins() {
+        self::ensureLoaded();
+        return self::$localCache['plugins'] ?? [];
+    }
+
+    /**
+     * Get timestamp of last successful refresh
+     *
+     * @return int|null Unix timestamp or null if never refreshed
+     */
+    public static function getLastRefresh() {
+        self::ensureLoaded();
+        return self::$localCache['last_refresh'] ?? null;
+    }
+
+    /**
+     * Get errors from last refresh attempt
+     *
+     * @return array Array of error messages with timestamps
+     */
+    public static function getRefreshErrors() {
+        if (self::hasAPCu()) {
+            $errors = apcu_fetch(self::getErrorsKey(), $success);
+            if ($success) {
+                return $errors;
+            }
+        }
+
+        // Fallback to file-based error storage
+        $errorFile = self::getCacheDir() . '/.plugin_errors_' . self::getTenantSlug() . '.json';
+        if (file_exists($errorFile)) {
+            $content = file_get_contents($errorFile);
+            return json_decode($content, true) ?: [];
+        }
+
+        return [];
+    }
+
+    /**
+     * Refresh plugin cache from configured sources
+     *
+     * @param bool $force Force refresh even if TTL hasn't expired
+     * @return array Result with 'success', 'count', 'errors' keys
+     */
+    public static function refresh($force = false) {
+        $logger = self::getLogger();
+        $startTime = microtime(true);
+
+        // Check if refresh is needed based on TTL
+        if (!$force) {
+            self::ensureLoaded();
+            $lastRefresh = self::$localCache['last_refresh'] ?? 0;
+            $ttl = self::getTTL();
+
+            if ($lastRefresh > 0 && (time() - $lastRefresh) < $ttl) {
+                $logger->debug('PluginRegistryCache: Skipping refresh, TTL not expired', [
+                    'last_refresh' => date('Y-m-d H:i:s', $lastRefresh),
+                    'ttl' => $ttl,
+                    'seconds_remaining' => $ttl - (time() - $lastRefresh)
+                ]);
+                return [
+                    'success' => true,
+                    'count' => count(self::$localCache['plugins'] ?? []),
+                    'errors' => [],
+                    'skipped' => true,
+                    'reason' => 'TTL not expired'
+                ];
+            }
+        }
+
+        $logger->info('PluginRegistryCache: Starting refresh', ['force' => $force]);
+
+        // Get configured sources
+        $sources = self::getConfiguredSources();
+
+        if (empty($sources)) {
+            $logger->warning('PluginRegistryCache: No plugin sources configured');
+            return [
+                'success' => false,
+                'count' => 0,
+                'errors' => ['No plugin sources configured']
+            ];
+        }
+
+        $plugins = [];
+        $errors = [];
+        $existingPlugins = self::$localCache['plugins'] ?? [];
+
+        // Scan each source
+        foreach ($sources as $source) {
+            try {
+                $sourcePlugins = self::scanSource($source);
+                $plugins = array_merge($plugins, $sourcePlugins);
+                $logger->debug('PluginRegistryCache: Scanned source', [
+                    'source' => $source,
+                    'plugins_found' => count($sourcePlugins)
+                ]);
+            } catch (\Exception $e) {
+                // On source error: preserve existing cached data, log error with timestamp
+                $errorEntry = [
+                    'source' => $source,
+                    'error' => $e->getMessage(),
+                    'timestamp' => date('Y-m-d H:i:s'),
+                    'unix_timestamp' => time()
+                ];
+                $errors[] = $errorEntry;
+
+                $logger->error('PluginRegistryCache: Source scan failed', [
+                    'source' => $source,
+                    'error' => $e->getMessage()
+                ]);
+
+                // Preserve existing plugins from this source if we have them
+                foreach ($existingPlugins as $existingPlugin) {
+                    if (isset($existingPlugin['source']) && $existingPlugin['source'] === $source) {
+                        $plugins[] = $existingPlugin;
+                    }
+                }
+            }
+        }
+
+        // Store errors
+        self::storeErrors($errors);
+
+        // Update cache with new plugins
+        self::$localCache = [
+            'plugins' => $plugins,
+            'last_refresh' => time(),
+            'refresh_duration_ms' => round((microtime(true) - $startTime) * 1000, 2)
+        ];
+
+        // Store in APCu if available
+        if (self::hasAPCu()) {
+            apcu_store(self::getCacheKey(), self::$localCache, self::getTTL());
+            $logger->info('PluginRegistryCache: Stored in APCu');
+        }
+
+        // Also store in file cache for persistence across APCu restarts
+        self::storeFileCache();
+
+        // Update version to invalidate old caches
+        $versionFile = self::getCacheVersionFile();
+        file_put_contents($versionFile, time());
+
+        // Reset cache keys so they use new version
+        self::$CACHE_KEY = null;
+        self::$STATS_KEY = null;
+        self::$ERRORS_KEY = null;
+
+        self::incrementStat('refreshes');
+
+        $logger->info('PluginRegistryCache: Refresh complete', [
+            'plugins_count' => count($plugins),
+            'errors_count' => count($errors),
+            'duration_ms' => self::$localCache['refresh_duration_ms']
+        ]);
+
+        return [
+            'success' => count($errors) === 0,
+            'count' => count($plugins),
+            'errors' => $errors,
+            'duration_ms' => self::$localCache['refresh_duration_ms']
+        ];
+    }
+
+    /**
+     * Invalidate (clear) the cache
+     */
+    public static function invalidate() {
+        $logger = self::getLogger();
+
+        // Clear local cache
+        self::$localCache = null;
+
+        // Clear APCu stats counters before changing version
+        if (self::hasAPCu()) {
+            $statsKey = self::getStatsKey();
+            $errorsKey = self::getErrorsKey();
+            apcu_delete(self::getCacheKey());
+            apcu_delete($statsKey . '_refreshes');
+            apcu_delete($statsKey . '_apcu_hits');
+            apcu_delete($errorsKey);
+        }
+
+        // Increment version file to invalidate all APCu caches across all processes
+        $versionFile = self::getCacheVersionFile();
+        $newVersion = time();
+        file_put_contents($versionFile, $newVersion);
+
+        // Clear file cache
+        $cacheFile = self::getFileCachePath();
+        if (file_exists($cacheFile)) {
+            @unlink($cacheFile);
+        }
+
+        // Clear errors file
+        $errorFile = self::getCacheDir() . '/.plugin_errors_' . self::getTenantSlug() . '.json';
+        if (file_exists($errorFile)) {
+            @unlink($errorFile);
+        }
+
+        // Reset cache keys so they use new version
+        self::$CACHE_KEY = null;
+        self::$STATS_KEY = null;
+        self::$ERRORS_KEY = null;
+        self::$CACHE_VERSION_FILE = null;
+
+        $logger->info('PluginRegistryCache: Cache invalidated (version: ' . $newVersion . ')');
+    }
+
+    /**
+     * Get cache statistics
+     *
+     * @return array Statistics array
+     */
+    public static function getStats() {
+        $apcu_hits = 0;
+        $refreshes = 0;
+
+        // Get APCu counters if available
+        if (self::hasAPCu()) {
+            $apcu_hits = apcu_fetch(self::getStatsKey() . '_apcu_hits') ?: 0;
+            $refreshes = apcu_fetch(self::getStatsKey() . '_refreshes') ?: 0;
+        }
+
+        self::ensureLoaded();
+
+        $stats = [
+            // Basic cache status
+            'apcu_available' => self::hasAPCu(),
+            'cache_loaded' => self::$localCache !== null,
+            'in_apcu' => false,
+
+            // Plugin counts and memory
+            'count' => count(self::$localCache['plugins'] ?? []),
+            'memory' => self::$localCache ? strlen(serialize(self::$localCache)) : 0,
+
+            // Cache performance metrics
+            'apcu_hits' => $apcu_hits,
+            'refreshes' => $refreshes,
+
+            // Timing info
+            'last_refresh' => self::$localCache['last_refresh'] ?? null,
+            'last_refresh_formatted' => isset(self::$localCache['last_refresh'])
+                ? date('Y-m-d H:i:s', self::$localCache['last_refresh'])
+                : 'Never',
+            'last_duration_ms' => self::$localCache['refresh_duration_ms'] ?? null,
+
+            // TTL info
+            'ttl' => self::getTTL(),
+            'ttl_remaining' => null,
+
+            // Cache version
+            'cache_version' => self::getCacheVersion(),
+
+            // Error count
+            'error_count' => count(self::getRefreshErrors())
+        ];
+
+        // Calculate remaining TTL
+        if (isset(self::$localCache['last_refresh'])) {
+            $elapsed = time() - self::$localCache['last_refresh'];
+            $remaining = self::getTTL() - $elapsed;
+            $stats['ttl_remaining'] = max(0, $remaining);
+        }
+
+        // Get additional APCu-specific stats
+        if (self::hasAPCu()) {
+            $stats['in_apcu'] = apcu_exists(self::getCacheKey());
+
+            if ($stats['in_apcu']) {
+                $info = apcu_key_info(self::getCacheKey());
+                if ($info) {
+                    $stats['apcu_ttl'] = $info['ttl'] ?? null;
+                    $stats['apcu_hits_on_key'] = $info['num_hits'] ?? null;
+                }
+            }
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Ensure cache is loaded into memory
+     */
+    private static function ensureLoaded() {
+        // If already in process memory, return immediately (fastest)
+        if (self::$localCache !== null) {
+            return;
+        }
+
+        // Try to load from APCu shared memory
+        if (self::hasAPCu()) {
+            self::$localCache = apcu_fetch(self::getCacheKey(), $success);
+            if ($success) {
+                self::getLogger()->debug('PluginRegistryCache: Loaded from APCu');
+                self::incrementStat('apcu_hits');
+                return;
+            }
+        }
+
+        // Try to load from file cache
+        self::loadFromFileCache();
+
+        // If still empty, initialize with empty structure
+        if (self::$localCache === null) {
+            self::$localCache = [
+                'plugins' => [],
+                'last_refresh' => null,
+                'refresh_duration_ms' => null
+            ];
+        }
+
+        // Store in APCu if available and we have data
+        if (self::hasAPCu() && !empty(self::$localCache['plugins'])) {
+            apcu_store(self::getCacheKey(), self::$localCache, self::getTTL());
+            self::getLogger()->info('PluginRegistryCache: Stored in APCu');
+        }
+    }
+
+    /**
+     * Get file cache path
+     */
+    private static function getFileCachePath() {
+        return self::getCacheDir() . '/plugin_registry_' . self::getTenantSlug() . '.cache';
+    }
+
+    /**
+     * Load cache from file
+     */
+    private static function loadFromFileCache() {
+        $cacheFile = self::getFileCachePath();
+        if (file_exists($cacheFile)) {
+            $content = file_get_contents($cacheFile);
+            $data = @unserialize($content);
+            if ($data !== false && is_array($data)) {
+                self::$localCache = $data;
+                self::getLogger()->debug('PluginRegistryCache: Loaded from file cache');
+                return;
+            }
+        }
+    }
+
+    /**
+     * Store cache to file
+     */
+    private static function storeFileCache() {
+        $cacheFile = self::getFileCachePath();
+        $content = serialize(self::$localCache);
+        file_put_contents($cacheFile, $content);
+    }
+
+    /**
+     * Store errors to persistent storage
+     */
+    private static function storeErrors($errors) {
+        // Store in APCu if available
+        if (self::hasAPCu()) {
+            apcu_store(self::getErrorsKey(), $errors, self::getTTL());
+        }
+
+        // Also store in file for persistence
+        $errorFile = self::getCacheDir() . '/.plugin_errors_' . self::getTenantSlug() . '.json';
+        file_put_contents($errorFile, json_encode($errors, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Get configured plugin sources
+     *
+     * @return array Array of source paths/URLs
+     */
+    private static function getConfiguredSources() {
+        try {
+            $sourcesConfig = Flight::get('plugin_registry.sources');
+            if (empty($sourcesConfig)) {
+                return [];
+            }
+
+            // Parse comma-separated list
+            $sources = array_map('trim', explode(',', $sourcesConfig));
+            return array_filter($sources); // Remove empty entries
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
+
+    /**
+     * Scan a single source for plugins
+     *
+     * @param string $source Source path or URL
+     * @return array Array of plugin metadata
+     * @throws \Exception If source cannot be scanned
+     */
+    private static function scanSource($source) {
+        $plugins = [];
+
+        // Determine if source is a local directory or remote URL
+        if (filter_var($source, FILTER_VALIDATE_URL)) {
+            // Remote source - fetch plugin manifest
+            $plugins = self::scanRemoteSource($source);
+        } else {
+            // Local directory
+            $plugins = self::scanLocalSource($source);
+        }
+
+        // Add source reference to each plugin
+        foreach ($plugins as &$plugin) {
+            $plugin['source'] = $source;
+        }
+
+        return $plugins;
+    }
+
+    /**
+     * Scan a local directory for plugins
+     *
+     * @param string $path Directory path
+     * @return array Array of plugin metadata
+     */
+    private static function scanLocalSource($path) {
+        $plugins = [];
+
+        // Handle relative paths
+        if (!str_starts_with($path, '/')) {
+            $path = dirname(__DIR__) . '/' . $path;
+        }
+
+        if (!is_dir($path)) {
+            throw new \Exception("Plugin source directory not found: {$path}");
+        }
+
+        // Look for plugin manifest files (plugin.json or manifest.json)
+        $iterator = new \DirectoryIterator($path);
+        foreach ($iterator as $item) {
+            if ($item->isDot() || !$item->isDir()) {
+                continue;
+            }
+
+            $pluginDir = $item->getPathname();
+            $manifestFile = null;
+
+            // Check for manifest files
+            foreach (['plugin.json', 'manifest.json'] as $manifestName) {
+                $candidatePath = $pluginDir . '/' . $manifestName;
+                if (file_exists($candidatePath)) {
+                    $manifestFile = $candidatePath;
+                    break;
+                }
+            }
+
+            if ($manifestFile) {
+                $content = file_get_contents($manifestFile);
+                $manifest = json_decode($content, true);
+
+                if ($manifest && isset($manifest['name'])) {
+                    $plugins[] = [
+                        'id' => $manifest['id'] ?? $item->getFilename(),
+                        'name' => $manifest['name'],
+                        'version' => $manifest['version'] ?? '1.0.0',
+                        'description' => $manifest['description'] ?? '',
+                        'author' => $manifest['author'] ?? 'Unknown',
+                        'path' => $pluginDir,
+                        'manifest' => $manifest,
+                        'scanned_at' => time()
+                    ];
+                }
+            }
+        }
+
+        return $plugins;
+    }
+
+    /**
+     * Scan a remote source for plugins
+     *
+     * @param string $url Remote URL (e.g., GitHub API endpoint)
+     * @return array Array of plugin metadata
+     */
+    private static function scanRemoteSource($url) {
+        $plugins = [];
+
+        // Set up HTTP context with timeout and user agent
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => 30,
+                'user_agent' => 'MyCTOBot-PluginRegistry/1.0',
+                'header' => "Accept: application/json\r\n"
+            ],
+            'ssl' => [
+                'verify_peer' => true,
+                'verify_peer_name' => true
+            ]
+        ]);
+
+        $response = @file_get_contents($url, false, $context);
+
+        if ($response === false) {
+            $error = error_get_last();
+            throw new \Exception("Failed to fetch remote source: " . ($error['message'] ?? 'Unknown error'));
+        }
+
+        $data = json_decode($response, true);
+
+        if (!is_array($data)) {
+            throw new \Exception("Invalid JSON response from remote source");
+        }
+
+        // Handle different response formats
+        if (isset($data['plugins']) && is_array($data['plugins'])) {
+            // Standard plugin registry format
+            foreach ($data['plugins'] as $plugin) {
+                if (isset($plugin['name'])) {
+                    $plugins[] = [
+                        'id' => $plugin['id'] ?? md5($plugin['name']),
+                        'name' => $plugin['name'],
+                        'version' => $plugin['version'] ?? '1.0.0',
+                        'description' => $plugin['description'] ?? '',
+                        'author' => $plugin['author'] ?? 'Unknown',
+                        'url' => $plugin['url'] ?? null,
+                        'manifest' => $plugin,
+                        'scanned_at' => time()
+                    ];
+                }
+            }
+        } elseif (isset($data['name'])) {
+            // Single plugin manifest
+            $plugins[] = [
+                'id' => $data['id'] ?? md5($data['name']),
+                'name' => $data['name'],
+                'version' => $data['version'] ?? '1.0.0',
+                'description' => $data['description'] ?? '',
+                'author' => $data['author'] ?? 'Unknown',
+                'url' => $url,
+                'manifest' => $data,
+                'scanned_at' => time()
+            ];
+        }
+
+        return $plugins;
+    }
+
+    /**
+     * Check if APCu is available and enabled
+     */
+    private static function hasAPCu() {
+        return function_exists('apcu_fetch') &&
+               function_exists('apcu_store') &&
+               ini_get('apc.enabled') &&
+               (php_sapi_name() !== 'cli' || ini_get('apc.enable_cli'));
+    }
+
+    /**
+     * Increment statistics counter
+     */
+    private static function incrementStat($stat) {
+        if (self::hasAPCu()) {
+            $key = self::getStatsKey() . '_' . $stat;
+            apcu_inc($key, 1, $success, self::getTTL());
+        }
+    }
+
+    /**
+     * Get logger instance
+     */
+    private static function getLogger() {
+        try {
+            return Flight::get('log');
+        } catch (\Exception $e) {
+            // Return a null logger if Flight not initialized (CLI mode)
+            return new class {
+                public function debug($msg, $ctx = []) {}
+                public function info($msg, $ctx = []) {}
+                public function warning($msg, $ctx = []) {}
+                public function error($msg, $ctx = []) {}
+            };
+        }
+    }
+
+    /**
+     * Warm up the cache (useful for deployment/startup)
+     *
+     * @return array Cache statistics after warmup
+     */
+    public static function warmup() {
+        self::invalidate();
+        self::refresh(true);
+        return self::getStats();
+    }
+
+    /**
+     * Reload cache from sources
+     *
+     * @return array Cache data after reload
+     */
+    public static function reload() {
+        self::invalidate();
+        self::refresh(true);
+        return self::$localCache;
+    }
+}

--- a/scripts/cron-plugin-registry.php
+++ b/scripts/cron-plugin-registry.php
@@ -1,0 +1,224 @@
+#!/usr/bin/env php
+<?php
+/**
+ * MyCTOBot Plugin Registry Cache Refresh
+ *
+ * Run this script via cron to keep plugin registry cache up to date.
+ * The script checks TTL and only refreshes when needed (unless --force is used).
+ *
+ * CRONTAB:
+ * --------
+ * # Run every hour (or adjust based on your refresh_interval config)
+ * 0 * * * * cd /path/to/myctobot/scripts && php cron-plugin-registry.php --script >> ../log/cron.log 2>&1
+ *
+ * # Or run every 15 minutes and let TTL control actual refreshes
+ * 0,15,30,45 * * * * cd /path/to/myctobot/scripts && php cron-plugin-registry.php --script >> ../log/cron.log 2>&1
+ *
+ * OPTIONS:
+ * --------
+ *   --script     REQUIRED for CLI execution
+ *   --tenant     Process specific tenant (e.g., gwt, greenworks). If omitted, processes all tenants.
+ *   --verbose    Show detailed output
+ *   --force      Force refresh regardless of TTL
+ *   --help       Show this help message
+ */
+
+// Determine paths
+$scriptDir = dirname(__FILE__);
+$baseDir = dirname($scriptDir);
+
+// Change to base directory
+chdir($baseDir);
+
+// Parse command line options
+$options = getopt('', ['verbose', 'force', 'script', 'tenant:', 'help']);
+
+if (isset($options['help'])) {
+    echo "MyCTOBot Plugin Registry Cache Refresh\n\n";
+    echo "Usage: php cron-plugin-registry.php --script [options]\n\n";
+    echo "Options:\n";
+    echo "  --script     REQUIRED for standalone script mode\n";
+    echo "  --tenant     Process specific tenant (omit to process all tenants)\n";
+    echo "  --verbose    Show detailed output\n";
+    echo "  --force      Force refresh regardless of TTL\n";
+    echo "  --help       Show this help message\n";
+    exit(0);
+}
+
+$verbose = isset($options['verbose']);
+$force = isset($options['force']);
+$specificTenant = $options['tenant'] ?? null;
+
+if ($verbose) {
+    echo "MyCTOBot Plugin Registry Refresh\n";
+    echo "================================\n";
+    echo "Time: " . date('Y-m-d H:i:s') . "\n";
+    echo "Base: {$baseDir}\n";
+    if ($specificTenant) echo "Tenant: {$specificTenant}\n";
+    if ($force) echo "Mode: FORCE (ignoring TTL)\n";
+    echo "\n";
+}
+
+// Load vendor autoload first
+require_once $baseDir . '/vendor/autoload.php';
+
+// Load bootstrap class and instantiate it
+require_once $baseDir . '/bootstrap.php';
+
+use \Flight as Flight;
+use \app\PluginRegistryCache;
+
+// Load the cache class
+require_once $baseDir . '/lib/PluginRegistryCache.php';
+
+try {
+    // Discover tenants to process
+    $tenantsToProcess = [];
+    if ($specificTenant) {
+        // Single tenant specified
+        $tenantConfig = $baseDir . "/conf/config.{$specificTenant}.ini";
+        if (!file_exists($tenantConfig)) {
+            echo "Error: Tenant config not found: {$tenantConfig}\n";
+            exit(1);
+        }
+        $tenantsToProcess[$specificTenant] = $tenantConfig;
+    } else {
+        // Discover all tenant configs
+        $configFiles = glob($baseDir . '/conf/config.*.ini');
+        foreach ($configFiles as $configFile) {
+            $basename = basename($configFile);
+            // Extract tenant name from config.{tenant}.ini
+            if (preg_match('/^config\.([a-z0-9]+)\.ini$/', $basename, $matches)) {
+                $tenantSlug = $matches[1];
+                // Skip 'example' config
+                if ($tenantSlug !== 'example') {
+                    $tenantsToProcess[$tenantSlug] = $configFile;
+                }
+            }
+        }
+    }
+
+    if (empty($tenantsToProcess)) {
+        if ($verbose) {
+            echo "No tenant configs found. Nothing to process.\n";
+        }
+        exit(0);
+    }
+
+    if ($verbose) {
+        echo "Tenants to process: " . implode(', ', array_keys($tenantsToProcess)) . "\n\n";
+    }
+
+    $totalProcessed = 0;
+    $totalErrors = 0;
+    $totalSkipped = 0;
+
+    // Process each tenant
+    foreach ($tenantsToProcess as $tenantSlug => $configFile) {
+        if ($verbose) {
+            echo "=== Processing tenant: {$tenantSlug} ===\n";
+        }
+
+        try {
+            // Initialize fresh bootstrap for this tenant
+            $bootstrap = new \app\Bootstrap($configFile);
+
+            // Set tenant in session for cache key differentiation
+            $_SESSION['tenant_slug'] = $tenantSlug;
+
+            // Set timezone from config
+            $configTimezone = Flight::get('app.timezone') ?? 'America/New_York';
+            date_default_timezone_set($configTimezone);
+
+            if ($verbose) {
+                echo "Tenant initialized, timezone: {$configTimezone}\n";
+
+                // Show current cache status
+                $stats = PluginRegistryCache::getStats();
+                echo "Current cache status:\n";
+                echo "  - Plugins cached: {$stats['count']}\n";
+                echo "  - Last refresh: {$stats['last_refresh_formatted']}\n";
+                echo "  - TTL: {$stats['ttl']} seconds\n";
+                if ($stats['ttl_remaining'] !== null) {
+                    echo "  - TTL remaining: {$stats['ttl_remaining']} seconds\n";
+                }
+                echo "\n";
+            }
+
+            // Perform the refresh
+            $result = PluginRegistryCache::refresh($force);
+
+            if (isset($result['skipped']) && $result['skipped']) {
+                $totalSkipped++;
+                if ($verbose) {
+                    echo "Skipped refresh: {$result['reason']}\n";
+                }
+            } else {
+                $totalProcessed++;
+                if ($verbose) {
+                    echo "Refresh completed:\n";
+                    echo "  - Plugins found: {$result['count']}\n";
+                    echo "  - Duration: " . ($result['duration_ms'] ?? 'N/A') . " ms\n";
+                    echo "  - Errors: " . count($result['errors']) . "\n";
+
+                    if (!empty($result['errors'])) {
+                        foreach ($result['errors'] as $error) {
+                            echo "    - [{$error['source']}] {$error['error']}\n";
+                        }
+                    }
+                }
+            }
+
+            // Count errors
+            $totalErrors += count($result['errors'] ?? []);
+
+            // Log the result
+            Flight::get('log')->info('Plugin registry cache refreshed', [
+                'tenant' => $tenantSlug,
+                'plugins_count' => $result['count'],
+                'errors_count' => count($result['errors'] ?? []),
+                'forced' => $force,
+                'skipped' => $result['skipped'] ?? false
+            ]);
+
+        } catch (\Exception $e) {
+            $totalErrors++;
+            if ($verbose) {
+                echo "Error processing tenant {$tenantSlug}: {$e->getMessage()}\n\n";
+            }
+        }
+
+        if ($verbose) {
+            echo "\n";
+        }
+    }
+
+    if ($verbose) {
+        echo "================================\n";
+        echo "All tenants complete!\n";
+        echo "Total processed: {$totalProcessed}\n";
+        echo "Total skipped (TTL): {$totalSkipped}\n";
+        echo "Total errors: {$totalErrors}\n";
+    }
+
+    exit($totalErrors > 0 ? 1 : 0);
+
+} catch (Exception $e) {
+    $message = "FATAL ERROR: " . $e->getMessage();
+
+    if ($verbose) {
+        echo "\n{$message}\n";
+        echo "Stack trace:\n" . $e->getTraceAsString() . "\n";
+    }
+
+    try {
+        $logger = Flight::get('log');
+        if ($logger) {
+            $logger->error($message, ['trace' => $e->getTraceAsString()]);
+        }
+    } catch (Exception $logError) {
+        // Ignore logging errors
+    }
+
+    exit(1);
+}

--- a/views/admin/plugin-cache.php
+++ b/views/admin/plugin-cache.php
@@ -1,0 +1,258 @@
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <h1 class="h3 mb-4">Plugin Registry Cache</h1>
+        </div>
+    </div>
+
+    <!-- Cache Actions -->
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="btn-group" role="group">
+                <a href="/admin/plugincache?action=refresh" class="btn btn-primary">
+                    <i class="bi bi-arrow-clockwise"></i> Refresh Cache
+                </a>
+                <a href="/admin/plugincache?action=invalidate" class="btn btn-danger"
+                   onclick="return confirm('Invalidate plugin cache? The cache will be empty until the next refresh.')">
+                    <i class="bi bi-trash"></i> Invalidate Cache
+                </a>
+                <a href="/admin/plugincache?action=warmup" class="btn btn-success">
+                    <i class="bi bi-lightning"></i> Warm Up Cache
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <!-- Cache Statistics -->
+        <div class="col-md-6 mb-4">
+            <div class="card">
+                <div class="card-header bg-primary text-white">
+                    <h5 class="mb-0"><i class="bi bi-speedometer2"></i> Cache Statistics</h5>
+                </div>
+                <div class="card-body">
+                    <?php if (isset($cache_stats) && is_array($cache_stats)): ?>
+                    <div class="row">
+                        <div class="col-6">
+                            <p><strong>APCu Available:</strong></p>
+                            <p><strong>Cache Loaded:</strong></p>
+                            <p><strong>In APCu:</strong></p>
+                            <p><strong>Cached Plugins:</strong></p>
+                            <p><strong>Memory Usage:</strong></p>
+                            <p><strong>Last Refresh:</strong></p>
+                            <p><strong>Last Duration:</strong></p>
+                            <p><strong>TTL:</strong></p>
+                            <p><strong>TTL Remaining:</strong></p>
+                        </div>
+                        <div class="col-6">
+                            <p>
+                                <?php if ($cache_stats['apcu_available']): ?>
+                                    <span class="badge bg-success">Yes</span>
+                                <?php else: ?>
+                                    <span class="badge bg-warning">No (using file cache)</span>
+                                <?php endif; ?>
+                            </p>
+                            <p>
+                                <?php if ($cache_stats['cache_loaded']): ?>
+                                    <span class="badge bg-success">Yes</span>
+                                <?php else: ?>
+                                    <span class="badge bg-secondary">No</span>
+                                <?php endif; ?>
+                            </p>
+                            <p>
+                                <?php if ($cache_stats['in_apcu']): ?>
+                                    <span class="badge bg-success">Yes</span>
+                                <?php else: ?>
+                                    <span class="badge bg-secondary">No</span>
+                                <?php endif; ?>
+                            </p>
+                            <p><strong><?= number_format($cache_stats['count'] ?? 0) ?></strong></p>
+                            <p><?= number_format(($cache_stats['memory'] ?? 0) / 1024, 2) ?> KB</p>
+                            <p>
+                                <?php if ($cache_stats['last_refresh']): ?>
+                                    <?= htmlspecialchars($cache_stats['last_refresh_formatted']) ?>
+                                <?php else: ?>
+                                    <span class="text-muted">Never</span>
+                                <?php endif; ?>
+                            </p>
+                            <p>
+                                <?php if ($cache_stats['last_duration_ms']): ?>
+                                    <?= number_format($cache_stats['last_duration_ms'], 2) ?> ms
+                                <?php else: ?>
+                                    <span class="text-muted">N/A</span>
+                                <?php endif; ?>
+                            </p>
+                            <p><?= number_format($cache_stats['ttl'] ?? 3600) ?> seconds</p>
+                            <p>
+                                <?php if ($cache_stats['ttl_remaining'] !== null): ?>
+                                    <?php
+                                    $remaining = $cache_stats['ttl_remaining'];
+                                    $ttl = $cache_stats['ttl'] ?? 3600;
+                                    $percent = $ttl > 0 ? ($remaining / $ttl) * 100 : 0;
+                                    $badgeClass = $percent > 50 ? 'bg-success' : ($percent > 20 ? 'bg-warning' : 'bg-danger');
+                                    ?>
+                                    <span class="badge <?= $badgeClass ?>"><?= number_format($remaining) ?>s</span>
+                                <?php else: ?>
+                                    <span class="text-muted">N/A</span>
+                                <?php endif; ?>
+                            </p>
+                        </div>
+                    </div>
+
+                    <?php if ($cache_stats['ttl_remaining'] !== null && $cache_stats['ttl'] > 0): ?>
+                    <?php
+                    $remaining = $cache_stats['ttl_remaining'];
+                    $ttl = $cache_stats['ttl'];
+                    $percent = ($remaining / $ttl) * 100;
+                    $barClass = $percent > 50 ? 'bg-success' : ($percent > 20 ? 'bg-warning' : 'bg-danger');
+                    ?>
+                    <div class="progress mt-3" style="height: 10px;">
+                        <div class="progress-bar <?= $barClass ?>"
+                             role="progressbar"
+                             style="width: <?= $percent ?>%"
+                             aria-valuenow="<?= $percent ?>"
+                             aria-valuemin="0"
+                             aria-valuemax="100"
+                             title="TTL Remaining: <?= number_format($remaining) ?>s">
+                        </div>
+                    </div>
+                    <small class="text-muted">TTL Progress (refreshes automatically when bar reaches 0)</small>
+                    <?php endif; ?>
+                    <?php else: ?>
+                    <p class="text-muted">No cache statistics available.</p>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+
+        <!-- Configured Sources -->
+        <div class="col-md-6 mb-4">
+            <div class="card">
+                <div class="card-header bg-info text-white">
+                    <h5 class="mb-0"><i class="bi bi-folder2-open"></i> Configured Sources</h5>
+                </div>
+                <div class="card-body">
+                    <?php if (!empty($sources)): ?>
+                    <ul class="list-group list-group-flush">
+                        <?php foreach ($sources as $source): ?>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <code><?= htmlspecialchars($source) ?></code>
+                            <?php if (filter_var($source, FILTER_VALIDATE_URL)): ?>
+                                <span class="badge bg-primary">Remote</span>
+                            <?php else: ?>
+                                <span class="badge bg-secondary">Local</span>
+                            <?php endif; ?>
+                        </li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <?php else: ?>
+                    <div class="alert alert-warning mb-0">
+                        <i class="bi bi-exclamation-triangle"></i> No plugin sources configured.
+                        <br><small>Add sources in <code>config.ini</code> under <code>[plugin_registry]</code> section.</small>
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Refresh Errors -->
+    <?php if (!empty($errors)): ?>
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="card border-danger">
+                <div class="card-header bg-danger text-white">
+                    <h5 class="mb-0"><i class="bi bi-exclamation-octagon"></i> Last Refresh Errors (<?= count($errors) ?>)</h5>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm table-striped mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Source</th>
+                                    <th>Error</th>
+                                    <th>Timestamp</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($errors as $error): ?>
+                                <tr>
+                                    <td><code><?= htmlspecialchars($error['source'] ?? 'Unknown') ?></code></td>
+                                    <td class="text-danger"><?= htmlspecialchars($error['error'] ?? 'Unknown error') ?></td>
+                                    <td>
+                                        <small class="text-muted"><?= htmlspecialchars($error['timestamp'] ?? 'N/A') ?></small>
+                                    </td>
+                                </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="alert alert-info mt-3 mb-0">
+                        <i class="bi bi-info-circle"></i> When a source fails to refresh, existing cached plugins from that source are preserved.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <!-- Cached Plugins Table -->
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="bi bi-plug"></i> Cached Plugins (<?= count($plugins ?? []) ?> entries)</h5>
+                </div>
+                <div class="card-body">
+                    <?php if (!empty($plugins)): ?>
+                    <div class="table-responsive">
+                        <table class="table table-sm table-striped table-hover">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Version</th>
+                                    <th>Author</th>
+                                    <th>Source</th>
+                                    <th>Scanned</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($plugins as $plugin): ?>
+                                <tr>
+                                    <td>
+                                        <strong><?= htmlspecialchars($plugin['name'] ?? 'Unknown') ?></strong>
+                                        <?php if (!empty($plugin['description'])): ?>
+                                        <br><small class="text-muted"><?= htmlspecialchars(substr($plugin['description'], 0, 100)) ?><?= strlen($plugin['description']) > 100 ? '...' : '' ?></small>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td><span class="badge bg-secondary"><?= htmlspecialchars($plugin['version'] ?? '1.0.0') ?></span></td>
+                                    <td><?= htmlspecialchars($plugin['author'] ?? 'Unknown') ?></td>
+                                    <td>
+                                        <code class="small"><?= htmlspecialchars(basename($plugin['source'] ?? 'unknown')) ?></code>
+                                    </td>
+                                    <td>
+                                        <?php if (!empty($plugin['scanned_at'])): ?>
+                                        <small class="text-muted"><?= date('Y-m-d H:i', $plugin['scanned_at']) ?></small>
+                                        <?php else: ?>
+                                        <small class="text-muted">N/A</small>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <?php else: ?>
+                    <div class="text-center py-4">
+                        <i class="bi bi-inbox text-muted" style="font-size: 3rem;"></i>
+                        <p class="text-muted mt-2">No plugins cached yet.</p>
+                        <a href="/admin/plugincache?action=refresh" class="btn btn-primary">
+                            <i class="bi bi-arrow-clockwise"></i> Refresh Cache Now
+                        </a>
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

Implements cache management for plugin metadata including refresh schedules, cache invalidation, and manual refresh capabilities.

- Add `PluginRegistryCache` class with APCu-based caching and file cache fallback
- Add cron script for scheduled automatic refresh based on TTL
- Add admin UI for cache management with refresh, invalidate, and warmup actions
- Add configuration section for plugin registry settings
- Implement error handling that preserves existing cached data when sources fail

## Acceptance Criteria

- [x] **Given** the plugin registry has cached data **When** the scheduled refresh time is reached **Then** the system automatically updates plugin information from sources
- [x] **Given** I am a system administrator **When** I trigger a manual cache refresh **Then** the system re-scans all configured sources and updates the plugin registry
- [x] **Given** a repository source becomes unavailable **When** refreshing the cache **Then** existing cached data is preserved and the error is logged with timestamp

## Files Changed

**New Files:**
- `lib/PluginRegistryCache.php` - Core cache class with APCu/file caching
- `scripts/cron-plugin-registry.php` - Cron script for scheduled refresh
- `views/admin/plugin-cache.php` - Admin UI for cache management

**Modified Files:**
- `controls/Admin.php` - Added admin routes for cache management
- `conf/config.example.ini` - Added [plugin_registry] configuration section

## Test Plan

- [ ] Verify cron script runs successfully with `php scripts/cron-plugin-registry.php --script --verbose`
- [ ] Test manual refresh via admin UI at `/admin/plugincache`
- [ ] Test cache invalidation via admin UI
- [ ] Verify error handling by configuring an invalid source and checking that existing data is preserved

Closes #106