### PR TITLE
Add plugin search functionality with relevance ranking (#102)

### DIFF
--- a/controls/Plugins.php
+++ b/controls/Plugins.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Plugins Controller
+ *
+ * Handles plugin marketplace listing with search and autocomplete functionality.
+ * Search results are ranked by relevance:
+ * - Exact name match: 100 points
+ * - Name contains: 80 points
+ * - Description contains: 50 points
+ * - Tags contain: 30 points
+ */
+
+namespace app;
+
+use \Flight as Flight;
+use \RedBeanPHP\R as R;
+use \Exception as Exception;
+use \app\services\PluginSearchService;
+
+require_once __DIR__ . '/../services/PluginSearchService.php';
+
+class Plugins extends BaseControls\Control {
+
+    /**
+     * Plugin marketplace index with search box
+     */
+    public function index($params = []) {
+        if (!$this->requireLogin()) return;
+
+        $query = trim($this->getParam('q', ''));
+        $category = $this->getParam('category', '');
+        $page = max(1, (int) $this->getParam('page', 1));
+        $limit = 20;
+        $offset = ($page - 1) * $limit;
+
+        // Get plugins based on search or default listing
+        if (!empty($query)) {
+            $plugins = PluginSearchService::search($query, [
+                'category' => $category,
+                'limit' => $limit,
+                'offset' => $offset
+            ]);
+            $noResultsSuggestions = empty($plugins)
+                ? PluginSearchService::getNoResultsSuggestions($query)
+                : null;
+        } else {
+            $plugins = PluginSearchService::getDefaultResults($category ?: null, $limit, $offset);
+            $noResultsSuggestions = null;
+        }
+
+        // Get categories for filtering
+        $categories = PluginSearchService::getCategoriesWithCounts();
+
+        // Calculate pagination info
+        $totalCount = $this->getPluginCount($query, $category);
+        $totalPages = max(1, ceil($totalCount / $limit));
+
+        $this->viewData['title'] = 'Plugin Marketplace';
+        $this->viewData['plugins'] = $plugins;
+        $this->viewData['query'] = $query;
+        $this->viewData['category'] = $category;
+        $this->viewData['categories'] = $categories;
+        $this->viewData['noResultsSuggestions'] = $noResultsSuggestions;
+        $this->viewData['pagination'] = [
+            'page' => $page,
+            'limit' => $limit,
+            'total' => $totalCount,
+            'totalPages' => $totalPages,
+            'hasNext' => $page < $totalPages,
+            'hasPrev' => $page > 1
+        ];
+
+        $this->render('plugins/index', $this->viewData);
+    }
+
+    /**
+     * Search API endpoint - returns JSON
+     */
+    public function search($params = []) {
+        if (!$this->requireLogin()) return;
+
+        $query = trim($this->getParam('q', ''));
+        $category = $this->getParam('category', '');
+        $limit = min((int) $this->getParam('limit', 20), 100);
+        $offset = (int) $this->getParam('offset', 0);
+
+        try {
+            if (empty($query)) {
+                $results = PluginSearchService::getDefaultResults(
+                    $category ?: null,
+                    $limit,
+                    $offset
+                );
+                $suggestions = null;
+            } else {
+                $results = PluginSearchService::search($query, [
+                    'category' => $category,
+                    'limit' => $limit,
+                    'offset' => $offset
+                ]);
+                $suggestions = empty($results)
+                    ? PluginSearchService::getNoResultsSuggestions($query)
+                    : null;
+            }
+
+            Flight::jsonSuccess([
+                'query' => $query,
+                'category' => $category,
+                'results' => $results,
+                'count' => count($results),
+                'suggestions' => $suggestions
+            ]);
+
+        } catch (Exception $e) {
+            $this->logger->error('Plugin search failed: ' . $e->getMessage());
+            Flight::jsonError('Search failed. Please try again.', 500);
+        }
+    }
+
+    /**
+     * Autocomplete API endpoint - returns JSON suggestions
+     */
+    public function autocomplete($params = []) {
+        if (!$this->requireLogin()) return;
+
+        $query = trim($this->getParam('q', ''));
+        $limit = min((int) $this->getParam('limit', 8), 20);
+
+        try {
+            if (strlen($query) < 2) {
+                Flight::jsonSuccess([
+                    'query' => $query,
+                    'suggestions' => []
+                ]);
+                return;
+            }
+
+            $suggestions = PluginSearchService::autocomplete($query, $limit);
+
+            Flight::jsonSuccess([
+                'query' => $query,
+                'suggestions' => $suggestions
+            ]);
+
+        } catch (Exception $e) {
+            $this->logger->error('Plugin autocomplete failed: ' . $e->getMessage());
+            Flight::jsonSuccess([
+                'query' => $query,
+                'suggestions' => []
+            ]);
+        }
+    }
+
+    /**
+     * View single plugin details
+     */
+    public function view($params = []) {
+        if (!$this->requireLogin()) return;
+
+        // Get plugin ID or slug from URL
+        $idOrSlug = $params['operation']->name ?? $this->getParam('id') ?? null;
+
+        if (empty($idOrSlug)) {
+            $this->flash('error', 'Plugin not found');
+            Flight::redirect('/plugins');
+            return;
+        }
+
+        try {
+            // Try to load by ID first, then by slug
+            if (is_numeric($idOrSlug)) {
+                $plugin = PluginSearchService::getById((int) $idOrSlug);
+            } else {
+                $plugin = PluginSearchService::getBySlug($idOrSlug);
+            }
+
+            if (!$plugin) {
+                $this->flash('error', 'Plugin not found');
+                Flight::redirect('/plugins');
+                return;
+            }
+
+            // Get related plugins
+            $relatedPlugins = PluginSearchService::getRelated($plugin['id'], 4);
+
+            // Increment view count (async - don't block page load)
+            $this->incrementViewCount($plugin['id']);
+
+            $this->viewData['title'] = $plugin['name'] . ' - Plugin Marketplace';
+            $this->viewData['plugin'] = $plugin;
+            $this->viewData['relatedPlugins'] = $relatedPlugins;
+            $this->viewData['categories'] = PluginSearchService::CATEGORIES;
+
+            $this->render('plugins/view', $this->viewData);
+
+        } catch (Exception $e) {
+            $this->logger->error('Plugin view failed: ' . $e->getMessage());
+            $this->flash('error', 'Failed to load plugin');
+            Flight::redirect('/plugins');
+        }
+    }
+
+    /**
+     * Get categories list API
+     */
+    public function categories($params = []) {
+        if (!$this->requireLogin()) return;
+
+        try {
+            $categories = PluginSearchService::getCategoriesWithCounts();
+
+            Flight::jsonSuccess([
+                'categories' => $categories
+            ]);
+
+        } catch (Exception $e) {
+            $this->logger->error('Get categories failed: ' . $e->getMessage());
+            Flight::jsonError('Failed to load categories', 500);
+        }
+    }
+
+    /**
+     * Get total plugin count for pagination
+     *
+     * @param string $query Search query
+     * @param string $category Category filter
+     * @return int Count
+     */
+    private function getPluginCount(string $query, string $category): int {
+        try {
+            $sql = "SELECT COUNT(*) FROM plugins WHERE is_active = 1";
+            $params = [];
+
+            if (!empty($query)) {
+                $searchTerm = '%' . $this->sanitizeSearchTerm($query) . '%';
+                $sql .= " AND (
+                    LOWER(name) LIKE LOWER(?)
+                    OR LOWER(short_description) LIKE LOWER(?)
+                    OR LOWER(description) LIKE LOWER(?)
+                )";
+                $params[] = $searchTerm;
+                $params[] = $searchTerm;
+                $params[] = $searchTerm;
+            }
+
+            if (!empty($category) && isset(PluginSearchService::CATEGORIES[$category])) {
+                $sql .= " AND category = ?";
+                $params[] = $category;
+            }
+
+            return (int) R::getCell($sql, $params);
+
+        } catch (Exception $e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Sanitize search term
+     *
+     * @param string $term Raw term
+     * @return string Sanitized term
+     */
+    private function sanitizeSearchTerm(string $term): string {
+        $term = preg_replace('/[%_\\\\]/', '', $term);
+        $term = preg_replace('/\s+/', ' ', $term);
+        return substr(trim($term), 0, 100);
+    }
+
+    /**
+     * Increment plugin view count (silent failure)
+     *
+     * @param int $pluginId Plugin ID
+     */
+    private function incrementViewCount(int $pluginId): void {
+        try {
+            // NOTE: Future upgrade consideration:
+            // Could track unique views per user/session for more accurate analytics
+            R::exec("UPDATE plugins SET download_count = download_count + 1 WHERE id = ?", [$pluginId]);
+        } catch (Exception $e) {
+            // Silent failure - don't affect user experience
+            $this->logger->debug('Failed to increment view count: ' . $e->getMessage());
+        }
+    }
+}

--- a/services/PluginSearchService.php
+++ b/services/PluginSearchService.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Plugin Search Service
+ *
+ * Handles plugin search operations with relevance ranking.
+ * Search scores are assigned based on match type:
+ * - Exact name match: 100
+ * - Name contains: 80
+ * - Description contains: 50
+ * - Tags contain: 30
+ */
+
+namespace app\services;
+
+use \RedBeanPHP\R as R;
+
+class PluginSearchService {
+
+    /**
+     * Available plugin categories
+     */
+    public const CATEGORIES = [
+        'general' => 'General',
+        'automation' => 'Automation',
+        'integration' => 'Integration',
+        'analytics' => 'Analytics',
+        'security' => 'Security',
+        'development' => 'Development',
+        'productivity' => 'Productivity',
+        'communication' => 'Communication'
+    ];
+
+    /**
+     * Search plugins with relevance ranking
+     *
+     * @param string $query Search query
+     * @param array $options Search options (category, limit, offset)
+     * @return array Results with relevance scores
+     */
+    public static function search(string $query, array $options = []): array {
+        $query = trim($query);
+        $category = $options['category'] ?? null;
+        $limit = min((int)($options['limit'] ?? 20), 100);
+        $offset = (int)($options['offset'] ?? 0);
+
+        if (empty($query)) {
+            return self::getDefaultResults($category, $limit, $offset);
+        }
+
+        // Sanitize and prepare query for LIKE searches
+        $searchTerm = '%' . self::sanitizeSearchTerm($query) . '%';
+        $exactTerm = self::sanitizeSearchTerm($query);
+
+        // Build SQL with relevance scoring
+        $sql = "
+            SELECT
+                p.*,
+                CASE
+                    WHEN LOWER(p.name) = LOWER(?) THEN 100
+                    WHEN LOWER(p.name) LIKE LOWER(?) THEN 80
+                    WHEN LOWER(p.short_description) LIKE LOWER(?) THEN 50
+                    WHEN LOWER(p.description) LIKE LOWER(?) THEN 45
+                    WHEN JSON_SEARCH(LOWER(p.tags), 'one', LOWER(?)) IS NOT NULL THEN 30
+                    ELSE 0
+                END AS relevance_score
+            FROM plugins p
+            WHERE p.is_active = 1
+            AND (
+                LOWER(p.name) LIKE LOWER(?)
+                OR LOWER(p.short_description) LIKE LOWER(?)
+                OR LOWER(p.description) LIKE LOWER(?)
+                OR JSON_SEARCH(LOWER(p.tags), 'one', LOWER(?)) IS NOT NULL
+            )
+        ";
+
+        $params = [
+            $exactTerm,      // Exact name match
+            $searchTerm,     // Name contains
+            $searchTerm,     // Short description contains
+            $searchTerm,     // Description contains
+            '%' . $exactTerm . '%', // Tags contain
+            $searchTerm,     // WHERE: Name contains
+            $searchTerm,     // WHERE: Short description contains
+            $searchTerm,     // WHERE: Description contains
+            '%' . $exactTerm . '%'  // WHERE: Tags contain
+        ];
+
+        // Add category filter if specified
+        if ($category && isset(self::CATEGORIES[$category])) {
+            $sql .= " AND p.category = ?";
+            $params[] = $category;
+        }
+
+        $sql .= " ORDER BY relevance_score DESC, p.download_count DESC, p.name ASC";
+        $sql .= " LIMIT ? OFFSET ?";
+        $params[] = $limit;
+        $params[] = $offset;
+
+        $results = R::getAll($sql, $params);
+
+        // Format results
+        return array_map(function($row) {
+            return self::formatPluginResult($row);
+        }, $results);
+    }
+
+    /**
+     * Get autocomplete suggestions for partial plugin names
+     *
+     * @param string $query Partial query
+     * @param int $limit Maximum suggestions
+     * @return array Suggestions
+     */
+    public static function autocomplete(string $query, int $limit = 8): array {
+        $query = trim($query);
+
+        if (strlen($query) < 2) {
+            return [];
+        }
+
+        $searchTerm = self::sanitizeSearchTerm($query) . '%';
+
+        $sql = "
+            SELECT id, name, slug, category, short_description
+            FROM plugins
+            WHERE is_active = 1
+            AND (
+                LOWER(name) LIKE LOWER(?)
+                OR LOWER(slug) LIKE LOWER(?)
+            )
+            ORDER BY
+                CASE WHEN LOWER(name) LIKE LOWER(?) THEN 0 ELSE 1 END,
+                download_count DESC,
+                name ASC
+            LIMIT ?
+        ";
+
+        $results = R::getAll($sql, [
+            $searchTerm,
+            $searchTerm,
+            $searchTerm,
+            $limit
+        ]);
+
+        return array_map(function($row) {
+            return [
+                'id' => (int) $row['id'],
+                'name' => $row['name'],
+                'slug' => $row['slug'],
+                'category' => $row['category'],
+                'short_description' => $row['short_description']
+                    ? substr($row['short_description'], 0, 80)
+                    : null
+            ];
+        }, $results);
+    }
+
+    /**
+     * Get default results (featured/popular plugins)
+     *
+     * @param string|null $category Optional category filter
+     * @param int $limit Limit
+     * @param int $offset Offset
+     * @return array
+     */
+    public static function getDefaultResults(?string $category = null, int $limit = 20, int $offset = 0): array {
+        $sql = "
+            SELECT p.*
+            FROM plugins p
+            WHERE p.is_active = 1
+        ";
+        $params = [];
+
+        if ($category && isset(self::CATEGORIES[$category])) {
+            $sql .= " AND p.category = ?";
+            $params[] = $category;
+        }
+
+        $sql .= " ORDER BY p.is_featured DESC, p.download_count DESC, p.rating DESC, p.name ASC";
+        $sql .= " LIMIT ? OFFSET ?";
+        $params[] = $limit;
+        $params[] = $offset;
+
+        $results = R::getAll($sql, $params);
+
+        return array_map(function($row) {
+            return self::formatPluginResult($row);
+        }, $results);
+    }
+
+    /**
+     * Get search suggestions when no results found
+     *
+     * @param string $query Original query
+     * @return array Suggestions
+     */
+    public static function getNoResultsSuggestions(string $query): array {
+        $suggestions = [];
+
+        // Get popular categories
+        $popularCategories = R::getAll("
+            SELECT category, COUNT(*) as count
+            FROM plugins
+            WHERE is_active = 1
+            GROUP BY category
+            ORDER BY count DESC
+            LIMIT 5
+        ");
+
+        // Get popular plugins
+        $popularPlugins = R::getAll("
+            SELECT id, name, slug, category
+            FROM plugins
+            WHERE is_active = 1
+            ORDER BY download_count DESC
+            LIMIT 5
+        ");
+
+        // Generate alternative search terms
+        $alternativeTerms = self::generateAlternativeTerms($query);
+
+        return [
+            'message' => "No plugins found for \"{$query}\"",
+            'tips' => [
+                'Try using broader search terms',
+                'Check the spelling of your search',
+                'Browse by category instead'
+            ],
+            'popular_categories' => array_map(function($cat) {
+                return [
+                    'key' => $cat['category'],
+                    'name' => self::CATEGORIES[$cat['category']] ?? ucfirst($cat['category']),
+                    'count' => (int) $cat['count']
+                ];
+            }, $popularCategories),
+            'popular_plugins' => array_map(function($plugin) {
+                return [
+                    'id' => (int) $plugin['id'],
+                    'name' => $plugin['name'],
+                    'slug' => $plugin['slug'],
+                    'category' => $plugin['category']
+                ];
+            }, $popularPlugins),
+            'alternative_terms' => $alternativeTerms
+        ];
+    }
+
+    /**
+     * Get available categories with plugin counts
+     *
+     * @return array Categories with counts
+     */
+    public static function getCategoriesWithCounts(): array {
+        $results = R::getAll("
+            SELECT category, COUNT(*) as count
+            FROM plugins
+            WHERE is_active = 1
+            GROUP BY category
+            ORDER BY count DESC
+        ");
+
+        $categories = [];
+        foreach ($results as $row) {
+            $key = $row['category'];
+            $categories[$key] = [
+                'key' => $key,
+                'name' => self::CATEGORIES[$key] ?? ucfirst($key),
+                'count' => (int) $row['count']
+            ];
+        }
+
+        // Include categories with zero count
+        foreach (self::CATEGORIES as $key => $name) {
+            if (!isset($categories[$key])) {
+                $categories[$key] = [
+                    'key' => $key,
+                    'name' => $name,
+                    'count' => 0
+                ];
+            }
+        }
+
+        return array_values($categories);
+    }
+
+    /**
+     * Format plugin result for API response
+     *
+     * @param array $row Database row
+     * @return array Formatted result
+     */
+    private static function formatPluginResult(array $row): array {
+        return [
+            'id' => (int) $row['id'],
+            'name' => $row['name'],
+            'slug' => $row['slug'],
+            'description' => $row['description'],
+            'short_description' => $row['short_description'],
+            'tags' => json_decode($row['tags'] ?: '[]', true),
+            'category' => $row['category'],
+            'category_name' => self::CATEGORIES[$row['category']] ?? ucfirst($row['category']),
+            'version' => $row['version'],
+            'author' => $row['author'],
+            'author_url' => $row['author_url'],
+            'icon_url' => $row['icon_url'],
+            'homepage_url' => $row['homepage_url'],
+            'documentation_url' => $row['documentation_url'],
+            'download_count' => (int) $row['download_count'],
+            'rating' => (float) $row['rating'],
+            'rating_count' => (int) $row['rating_count'],
+            'is_featured' => (bool) $row['is_featured'],
+            'is_verified' => (bool) $row['is_verified'],
+            'relevance_score' => isset($row['relevance_score']) ? (int) $row['relevance_score'] : null,
+            'created_at' => $row['created_at'],
+            'updated_at' => $row['updated_at']
+        ];
+    }
+
+    /**
+     * Sanitize search term to prevent SQL injection and normalize input
+     *
+     * @param string $term Raw search term
+     * @return string Sanitized term
+     */
+    private static function sanitizeSearchTerm(string $term): string {
+        // Remove special characters that could interfere with LIKE
+        $term = preg_replace('/[%_\\\\]/', '', $term);
+        // Remove excessive whitespace
+        $term = preg_replace('/\s+/', ' ', $term);
+        // Trim and limit length
+        return substr(trim($term), 0, 100);
+    }
+
+    /**
+     * Generate alternative search terms
+     *
+     * @param string $query Original query
+     * @return array Alternative terms
+     */
+    private static function generateAlternativeTerms(string $query): array {
+        $alternatives = [];
+        $words = explode(' ', strtolower($query));
+
+        // Suggest individual words if multi-word query
+        if (count($words) > 1) {
+            foreach ($words as $word) {
+                if (strlen($word) >= 3) {
+                    $alternatives[] = $word;
+                }
+            }
+        }
+
+        // Common synonyms and related terms
+        $synonyms = [
+            'auth' => ['authentication', 'login', 'security'],
+            'db' => ['database', 'storage'],
+            'api' => ['integration', 'rest', 'webhook'],
+            'mail' => ['email', 'notification'],
+            'chat' => ['messaging', 'communication'],
+            'ai' => ['artificial intelligence', 'machine learning', 'automation'],
+            'log' => ['logging', 'monitoring', 'analytics']
+        ];
+
+        foreach ($words as $word) {
+            if (isset($synonyms[$word])) {
+                $alternatives = array_merge($alternatives, $synonyms[$word]);
+            }
+        }
+
+        return array_unique(array_slice($alternatives, 0, 5));
+    }
+
+    /**
+     * Get a single plugin by ID
+     *
+     * @param int $id Plugin ID
+     * @return array|null Plugin data or null
+     */
+    public static function getById(int $id): ?array {
+        $row = R::getRow("
+            SELECT * FROM plugins WHERE id = ? AND is_active = 1
+        ", [$id]);
+
+        return $row ? self::formatPluginResult($row) : null;
+    }
+
+    /**
+     * Get a single plugin by slug
+     *
+     * @param string $slug Plugin slug
+     * @return array|null Plugin data or null
+     */
+    public static function getBySlug(string $slug): ?array {
+        $row = R::getRow("
+            SELECT * FROM plugins WHERE slug = ? AND is_active = 1
+        ", [$slug]);
+
+        return $row ? self::formatPluginResult($row) : null;
+    }
+
+    /**
+     * Get related plugins based on category and tags
+     *
+     * @param int $pluginId Current plugin ID
+     * @param int $limit Maximum results
+     * @return array Related plugins
+     */
+    public static function getRelated(int $pluginId, int $limit = 4): array {
+        // Get the current plugin's info
+        $plugin = R::getRow("SELECT category, tags FROM plugins WHERE id = ?", [$pluginId]);
+        if (!$plugin) {
+            return [];
+        }
+
+        $results = R::getAll("
+            SELECT *
+            FROM plugins
+            WHERE id != ?
+            AND is_active = 1
+            AND category = ?
+            ORDER BY download_count DESC, rating DESC
+            LIMIT ?
+        ", [$pluginId, $plugin['category'], $limit]);
+
+        return array_map(function($row) {
+            return self::formatPluginResult($row);
+        }, $results);
+    }
+}

--- a/sql/tenant_schema.sql
+++ b/sql/tenant_schema.sql
@@ -639,6 +639,43 @@ CREATE TABLE IF NOT EXISTS `ctostories` (
     FOREIGN KEY (`epic_id`) REFERENCES `ctoepics`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- ============================================================================
+-- PLUGIN MARKETPLACE TABLES
+-- ============================================================================
+
+-- Plugins table for plugin marketplace
+CREATE TABLE IF NOT EXISTS `plugins` (
+    `id` INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    `member_id` INT NOT NULL,
+    `name` VARCHAR(100) NOT NULL,
+    `slug` VARCHAR(100) NOT NULL,
+    `description` TEXT,
+    `short_description` VARCHAR(255),
+    `tags` JSON DEFAULT '[]',
+    `category` VARCHAR(50) DEFAULT 'general',
+    `version` VARCHAR(20) DEFAULT '1.0.0',
+    `author` VARCHAR(100),
+    `author_url` VARCHAR(255),
+    `icon_url` VARCHAR(500),
+    `homepage_url` VARCHAR(500),
+    `documentation_url` VARCHAR(500),
+    `download_count` INT DEFAULT 0,
+    `rating` DECIMAL(2,1) DEFAULT 0.0,
+    `rating_count` INT DEFAULT 0,
+    `is_active` TINYINT(1) DEFAULT 1,
+    `is_featured` TINYINT(1) DEFAULT 0,
+    `is_verified` TINYINT(1) DEFAULT 0,
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY `uk_slug` (`slug`),
+    INDEX `idx_member` (`member_id`),
+    INDEX `idx_category` (`category`),
+    INDEX `idx_active` (`is_active`),
+    INDEX `idx_featured` (`is_featured`),
+    INDEX `idx_name` (`name`),
+    FULLTEXT INDEX `ft_search` (`name`, `description`, `short_description`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Directive Processing Log
 CREATE TABLE IF NOT EXISTS `directivelogs` (
     `id` INT AUTO_INCREMENT PRIMARY KEY,
@@ -664,7 +701,11 @@ INSERT INTO `authcontrol` (`control`, `method`, `level`, `description`) VALUES
 ('projects', 'report', 100, 'Generate project report'),
 ('projects', 'pause', 100, 'Pause project execution'),
 ('projects', 'resume', 100, 'Resume project execution'),
-('webhook', 'mailgun', 101, 'Mailgun incoming email webhook')
+('webhook', 'mailgun', 101, 'Mailgun incoming email webhook'),
+('plugins', 'index', 100, 'Plugin marketplace listing'),
+('plugins', 'search', 100, 'Search plugins'),
+('plugins', 'autocomplete', 100, 'Plugin name autocomplete'),
+('plugins', 'view', 100, 'View plugin details')
 ON DUPLICATE KEY UPDATE `level` = VALUES(`level`);
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/views/plugins/index.php
+++ b/views/plugins/index.php
@@ -1,0 +1,493 @@
+<?php $csrf = $csrf['csrf_token'] ?? ''; ?>
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h2 mb-0">
+            <i class="bi bi-puzzle"></i> Plugin Marketplace
+        </h1>
+    </div>
+
+    <!-- Search Section -->
+    <div class="card mb-4">
+        <div class="card-body">
+            <form method="GET" action="/plugins" id="searchForm" class="row g-3 align-items-end">
+                <div class="col-md-6 col-lg-7">
+                    <label for="searchInput" class="form-label">Search Plugins</label>
+                    <div class="position-relative">
+                        <input type="text"
+                               class="form-control form-control-lg"
+                               id="searchInput"
+                               name="q"
+                               value="<?= htmlspecialchars($query ?? '') ?>"
+                               placeholder="Search by name, description, or tags..."
+                               autocomplete="off">
+                        <div id="autocompleteDropdown" class="autocomplete-dropdown"></div>
+                    </div>
+                </div>
+                <div class="col-md-4 col-lg-3">
+                    <label for="categorySelect" class="form-label">Category</label>
+                    <select class="form-select form-select-lg" id="categorySelect" name="category">
+                        <option value="">All Categories</option>
+                        <?php foreach ($categories as $cat): ?>
+                        <option value="<?= htmlspecialchars($cat['key']) ?>"
+                                <?= ($category ?? '') === $cat['key'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($cat['name']) ?> (<?= $cat['count'] ?>)
+                        </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <button type="submit" class="btn btn-primary btn-lg w-100">
+                        <i class="bi bi-search"></i> Search
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <?php if (!empty($query)): ?>
+    <!-- Active Search Indicator -->
+    <div class="mb-3">
+        <span class="badge bg-info fs-6">
+            <i class="bi bi-search"></i> Results for: "<?= htmlspecialchars($query) ?>"
+        </span>
+        <?php if (!empty($category)): ?>
+        <span class="badge bg-secondary fs-6 ms-1">
+            Category: <?= htmlspecialchars($categories[array_search($category, array_column($categories, 'key'))]['name'] ?? $category) ?>
+        </span>
+        <?php endif; ?>
+        <a href="/plugins" class="btn btn-sm btn-outline-secondary ms-2">
+            <i class="bi bi-x-lg"></i> Clear Search
+        </a>
+    </div>
+    <?php endif; ?>
+
+    <?php if (empty($plugins) && !empty($noResultsSuggestions)): ?>
+    <!-- No Results - Helpful Suggestions -->
+    <div class="card border-warning">
+        <div class="card-body text-center py-5">
+            <i class="bi bi-search display-4 text-muted"></i>
+            <h4 class="mt-3"><?= htmlspecialchars($noResultsSuggestions['message']) ?></h4>
+
+            <div class="mt-4 text-start" style="max-width: 600px; margin: 0 auto;">
+                <h5><i class="bi bi-lightbulb"></i> Search Tips</h5>
+                <ul class="text-muted">
+                    <?php foreach ($noResultsSuggestions['tips'] as $tip): ?>
+                    <li><?= htmlspecialchars($tip) ?></li>
+                    <?php endforeach; ?>
+                </ul>
+
+                <?php if (!empty($noResultsSuggestions['alternative_terms'])): ?>
+                <h5 class="mt-4"><i class="bi bi-arrow-right-circle"></i> Try These Search Terms</h5>
+                <div class="d-flex flex-wrap gap-2">
+                    <?php foreach ($noResultsSuggestions['alternative_terms'] as $term): ?>
+                    <a href="/plugins?q=<?= urlencode($term) ?>" class="btn btn-outline-primary btn-sm">
+                        <?= htmlspecialchars($term) ?>
+                    </a>
+                    <?php endforeach; ?>
+                </div>
+                <?php endif; ?>
+
+                <?php if (!empty($noResultsSuggestions['popular_categories'])): ?>
+                <h5 class="mt-4"><i class="bi bi-folder"></i> Browse Popular Categories</h5>
+                <div class="d-flex flex-wrap gap-2">
+                    <?php foreach ($noResultsSuggestions['popular_categories'] as $cat): ?>
+                    <a href="/plugins?category=<?= urlencode($cat['key']) ?>" class="btn btn-outline-secondary btn-sm">
+                        <?= htmlspecialchars($cat['name']) ?>
+                        <span class="badge bg-secondary ms-1"><?= $cat['count'] ?></span>
+                    </a>
+                    <?php endforeach; ?>
+                </div>
+                <?php endif; ?>
+
+                <?php if (!empty($noResultsSuggestions['popular_plugins'])): ?>
+                <h5 class="mt-4"><i class="bi bi-star"></i> Popular Plugins</h5>
+                <div class="list-group">
+                    <?php foreach ($noResultsSuggestions['popular_plugins'] as $plugin): ?>
+                    <a href="/plugins/view/<?= htmlspecialchars($plugin['slug']) ?>" class="list-group-item list-group-item-action">
+                        <strong><?= htmlspecialchars($plugin['name']) ?></strong>
+                        <span class="badge bg-info ms-2"><?= htmlspecialchars($plugin['category']) ?></span>
+                    </a>
+                    <?php endforeach; ?>
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <?php elseif (empty($plugins)): ?>
+    <!-- No Plugins Available -->
+    <div class="card">
+        <div class="card-body text-center py-5">
+            <i class="bi bi-puzzle display-4 text-muted"></i>
+            <h4 class="mt-3">No plugins available yet</h4>
+            <p class="text-muted">Check back later for new plugins.</p>
+        </div>
+    </div>
+
+    <?php else: ?>
+    <!-- Plugin Grid -->
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-4">
+        <?php foreach ($plugins as $plugin): ?>
+        <div class="col">
+            <div class="card h-100 plugin-card">
+                <div class="card-header bg-transparent d-flex justify-content-between align-items-center">
+                    <span class="badge bg-<?= getCategoryBadgeClass($plugin['category']) ?>">
+                        <?= htmlspecialchars($plugin['category_name']) ?>
+                    </span>
+                    <div>
+                        <?php if ($plugin['is_featured']): ?>
+                        <span class="badge bg-warning text-dark" title="Featured">
+                            <i class="bi bi-star-fill"></i>
+                        </span>
+                        <?php endif; ?>
+                        <?php if ($plugin['is_verified']): ?>
+                        <span class="badge bg-success" title="Verified">
+                            <i class="bi bi-patch-check-fill"></i>
+                        </span>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <?php if ($plugin['icon_url']): ?>
+                    <div class="text-center mb-3">
+                        <img src="<?= htmlspecialchars($plugin['icon_url']) ?>"
+                             alt="<?= htmlspecialchars($plugin['name']) ?>"
+                             class="plugin-icon" style="max-width: 64px; max-height: 64px;">
+                    </div>
+                    <?php else: ?>
+                    <div class="text-center mb-3">
+                        <i class="bi bi-puzzle display-4 text-muted"></i>
+                    </div>
+                    <?php endif; ?>
+
+                    <h5 class="card-title">
+                        <a href="/plugins/view/<?= htmlspecialchars($plugin['slug']) ?>" class="text-decoration-none">
+                            <?= htmlspecialchars($plugin['name']) ?>
+                        </a>
+                    </h5>
+
+                    <p class="card-text text-muted small">
+                        <?= htmlspecialchars($plugin['short_description'] ?: substr($plugin['description'] ?? '', 0, 100)) ?>
+                        <?php if (strlen($plugin['description'] ?? '') > 100 && !$plugin['short_description']): ?>...<?php endif; ?>
+                    </p>
+
+                    <?php if (!empty($plugin['tags'])): ?>
+                    <div class="mb-2">
+                        <?php foreach (array_slice($plugin['tags'], 0, 3) as $tag): ?>
+                        <span class="badge bg-light text-dark"><?= htmlspecialchars($tag) ?></span>
+                        <?php endforeach; ?>
+                        <?php if (count($plugin['tags']) > 3): ?>
+                        <span class="badge bg-light text-dark">+<?= count($plugin['tags']) - 3 ?></span>
+                        <?php endif; ?>
+                    </div>
+                    <?php endif; ?>
+
+                    <?php if ($plugin['relevance_score'] !== null && !empty($query)): ?>
+                    <div class="mb-2">
+                        <span class="badge bg-info" title="Search relevance score">
+                            <i class="bi bi-bullseye"></i> <?= $plugin['relevance_score'] ?>% match
+                        </span>
+                    </div>
+                    <?php endif; ?>
+                </div>
+                <div class="card-footer bg-transparent">
+                    <div class="d-flex justify-content-between align-items-center small text-muted">
+                        <span title="Downloads">
+                            <i class="bi bi-download"></i> <?= number_format($plugin['download_count']) ?>
+                        </span>
+                        <span title="Rating">
+                            <?php if ($plugin['rating'] > 0): ?>
+                            <i class="bi bi-star-fill text-warning"></i>
+                            <?= number_format($plugin['rating'], 1) ?>
+                            <?php else: ?>
+                            <i class="bi bi-star text-muted"></i> No ratings
+                            <?php endif; ?>
+                        </span>
+                        <span title="Version">
+                            v<?= htmlspecialchars($plugin['version']) ?>
+                        </span>
+                    </div>
+                    <div class="mt-2">
+                        <a href="/plugins/view/<?= htmlspecialchars($plugin['slug']) ?>"
+                           class="btn btn-sm btn-outline-primary w-100">
+                            <i class="bi bi-eye"></i> View Details
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <?php endforeach; ?>
+    </div>
+
+    <!-- Pagination -->
+    <?php if ($pagination['totalPages'] > 1): ?>
+    <nav class="mt-4" aria-label="Plugin pagination">
+        <ul class="pagination justify-content-center">
+            <li class="page-item <?= !$pagination['hasPrev'] ? 'disabled' : '' ?>">
+                <a class="page-link" href="<?= buildPaginationUrl($pagination['page'] - 1, $query, $category) ?>">
+                    <i class="bi bi-chevron-left"></i> Previous
+                </a>
+            </li>
+
+            <?php
+            $startPage = max(1, $pagination['page'] - 2);
+            $endPage = min($pagination['totalPages'], $pagination['page'] + 2);
+            ?>
+
+            <?php if ($startPage > 1): ?>
+            <li class="page-item">
+                <a class="page-link" href="<?= buildPaginationUrl(1, $query, $category) ?>">1</a>
+            </li>
+            <?php if ($startPage > 2): ?>
+            <li class="page-item disabled"><span class="page-link">...</span></li>
+            <?php endif; ?>
+            <?php endif; ?>
+
+            <?php for ($i = $startPage; $i <= $endPage; $i++): ?>
+            <li class="page-item <?= $i === $pagination['page'] ? 'active' : '' ?>">
+                <a class="page-link" href="<?= buildPaginationUrl($i, $query, $category) ?>"><?= $i ?></a>
+            </li>
+            <?php endfor; ?>
+
+            <?php if ($endPage < $pagination['totalPages']): ?>
+            <?php if ($endPage < $pagination['totalPages'] - 1): ?>
+            <li class="page-item disabled"><span class="page-link">...</span></li>
+            <?php endif; ?>
+            <li class="page-item">
+                <a class="page-link" href="<?= buildPaginationUrl($pagination['totalPages'], $query, $category) ?>">
+                    <?= $pagination['totalPages'] ?>
+                </a>
+            </li>
+            <?php endif; ?>
+
+            <li class="page-item <?= !$pagination['hasNext'] ? 'disabled' : '' ?>">
+                <a class="page-link" href="<?= buildPaginationUrl($pagination['page'] + 1, $query, $category) ?>">
+                    Next <i class="bi bi-chevron-right"></i>
+                </a>
+            </li>
+        </ul>
+    </nav>
+    <div class="text-center text-muted small">
+        Showing <?= (($pagination['page'] - 1) * $pagination['limit']) + 1 ?>
+        - <?= min($pagination['page'] * $pagination['limit'], $pagination['total']) ?>
+        of <?= number_format($pagination['total']) ?> plugins
+    </div>
+    <?php endif; ?>
+
+    <?php endif; ?>
+</div>
+
+<?php
+// Helper function for category badge colors
+function getCategoryBadgeClass($category) {
+    $classes = [
+        'general' => 'secondary',
+        'automation' => 'primary',
+        'integration' => 'info',
+        'analytics' => 'success',
+        'security' => 'danger',
+        'development' => 'dark',
+        'productivity' => 'warning',
+        'communication' => 'purple'
+    ];
+    return $classes[$category] ?? 'secondary';
+}
+
+// Helper function for pagination URLs
+function buildPaginationUrl($page, $query, $category) {
+    $params = ['page' => $page];
+    if (!empty($query)) $params['q'] = $query;
+    if (!empty($category)) $params['category'] = $category;
+    return '/plugins?' . http_build_query($params);
+}
+?>
+
+<style>
+.autocomplete-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: white;
+    border: 1px solid #dee2e6;
+    border-top: none;
+    border-radius: 0 0 0.375rem 0.375rem;
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+    display: none;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.autocomplete-dropdown.show {
+    display: block;
+}
+
+.autocomplete-item {
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.autocomplete-item:last-child {
+    border-bottom: none;
+}
+
+.autocomplete-item:hover,
+.autocomplete-item.active {
+    background-color: #f8f9fa;
+}
+
+.autocomplete-item .plugin-name {
+    font-weight: 600;
+}
+
+.autocomplete-item .plugin-category {
+    font-size: 0.8rem;
+    color: #6c757d;
+}
+
+.autocomplete-item .plugin-desc {
+    font-size: 0.85rem;
+    color: #6c757d;
+    margin-top: 0.25rem;
+}
+
+.plugin-card {
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.plugin-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+
+.bg-purple {
+    background-color: #6f42c1 !important;
+    color: white;
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const searchInput = document.getElementById('searchInput');
+    const dropdown = document.getElementById('autocompleteDropdown');
+    const categorySelect = document.getElementById('categorySelect');
+    let debounceTimer = null;
+    let activeIndex = -1;
+    let suggestions = [];
+
+    // Debounced autocomplete search
+    searchInput.addEventListener('input', function() {
+        const query = this.value.trim();
+
+        clearTimeout(debounceTimer);
+
+        if (query.length < 2) {
+            hideDropdown();
+            return;
+        }
+
+        debounceTimer = setTimeout(function() {
+            fetchAutocomplete(query);
+        }, 300);
+    });
+
+    // Keyboard navigation
+    searchInput.addEventListener('keydown', function(e) {
+        if (!dropdown.classList.contains('show')) return;
+
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            activeIndex = Math.min(activeIndex + 1, suggestions.length - 1);
+            updateActiveItem();
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            activeIndex = Math.max(activeIndex - 1, -1);
+            updateActiveItem();
+        } else if (e.key === 'Enter' && activeIndex >= 0) {
+            e.preventDefault();
+            selectSuggestion(suggestions[activeIndex]);
+        } else if (e.key === 'Escape') {
+            hideDropdown();
+        }
+    });
+
+    // Click outside to close
+    document.addEventListener('click', function(e) {
+        if (!searchInput.contains(e.target) && !dropdown.contains(e.target)) {
+            hideDropdown();
+        }
+    });
+
+    // Category change auto-submit
+    categorySelect.addEventListener('change', function() {
+        document.getElementById('searchForm').submit();
+    });
+
+    function fetchAutocomplete(query) {
+        fetch('/plugins/autocomplete?q=' + encodeURIComponent(query), {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success && data.data && data.data.suggestions) {
+                suggestions = data.data.suggestions;
+                renderDropdown(suggestions);
+            }
+        })
+        .catch(error => {
+            console.error('Autocomplete error:', error);
+        });
+    }
+
+    function renderDropdown(items) {
+        if (items.length === 0) {
+            hideDropdown();
+            return;
+        }
+
+        dropdown.innerHTML = items.map((item, index) => `
+            <div class="autocomplete-item" data-index="${index}">
+                <div class="plugin-name">${escapeHtml(item.name)}</div>
+                <span class="plugin-category badge bg-secondary">${escapeHtml(item.category)}</span>
+                ${item.short_description ? `<div class="plugin-desc">${escapeHtml(item.short_description)}</div>` : ''}
+            </div>
+        `).join('');
+
+        // Add click handlers
+        dropdown.querySelectorAll('.autocomplete-item').forEach((item, index) => {
+            item.addEventListener('click', function() {
+                selectSuggestion(suggestions[index]);
+            });
+        });
+
+        activeIndex = -1;
+        dropdown.classList.add('show');
+    }
+
+    function hideDropdown() {
+        dropdown.classList.remove('show');
+        activeIndex = -1;
+    }
+
+    function updateActiveItem() {
+        dropdown.querySelectorAll('.autocomplete-item').forEach((item, index) => {
+            item.classList.toggle('active', index === activeIndex);
+        });
+    }
+
+    function selectSuggestion(suggestion) {
+        // Navigate directly to the plugin
+        window.location.href = '/plugins/view/' + suggestion.slug;
+    }
+
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+});
+</script>

--- a/views/plugins/view.php
+++ b/views/plugins/view.php
@@ -1,0 +1,328 @@
+<?php $csrf = $csrf['csrf_token'] ?? ''; ?>
+<div class="container py-4">
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb" class="mb-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/plugins"><i class="bi bi-puzzle"></i> Plugins</a></li>
+            <li class="breadcrumb-item">
+                <a href="/plugins?category=<?= urlencode($plugin['category']) ?>">
+                    <?= htmlspecialchars($plugin['category_name']) ?>
+                </a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">
+                <?= htmlspecialchars($plugin['name']) ?>
+            </li>
+        </ol>
+    </nav>
+
+    <div class="row">
+        <!-- Main Content -->
+        <div class="col-lg-8">
+            <div class="card mb-4">
+                <div class="card-body">
+                    <!-- Plugin Header -->
+                    <div class="d-flex align-items-start mb-4">
+                        <?php if ($plugin['icon_url']): ?>
+                        <img src="<?= htmlspecialchars($plugin['icon_url']) ?>"
+                             alt="<?= htmlspecialchars($plugin['name']) ?>"
+                             class="me-4" style="width: 80px; height: 80px; object-fit: contain;">
+                        <?php else: ?>
+                        <div class="me-4 d-flex align-items-center justify-content-center bg-light rounded"
+                             style="width: 80px; height: 80px;">
+                            <i class="bi bi-puzzle display-4 text-muted"></i>
+                        </div>
+                        <?php endif; ?>
+
+                        <div class="flex-grow-1">
+                            <h1 class="h2 mb-2">
+                                <?= htmlspecialchars($plugin['name']) ?>
+                                <?php if ($plugin['is_verified']): ?>
+                                <span class="badge bg-success ms-2" title="Verified Plugin">
+                                    <i class="bi bi-patch-check-fill"></i> Verified
+                                </span>
+                                <?php endif; ?>
+                                <?php if ($plugin['is_featured']): ?>
+                                <span class="badge bg-warning text-dark ms-2" title="Featured Plugin">
+                                    <i class="bi bi-star-fill"></i> Featured
+                                </span>
+                                <?php endif; ?>
+                            </h1>
+
+                            <p class="lead text-muted mb-2">
+                                <?= htmlspecialchars($plugin['short_description'] ?: substr($plugin['description'], 0, 150)) ?>
+                            </p>
+
+                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                <span class="badge bg-<?= getCategoryBadgeClass($plugin['category']) ?> fs-6">
+                                    <?= htmlspecialchars($plugin['category_name']) ?>
+                                </span>
+                                <span class="badge bg-secondary fs-6">
+                                    v<?= htmlspecialchars($plugin['version']) ?>
+                                </span>
+                            </div>
+
+                            <?php if ($plugin['author']): ?>
+                            <div class="text-muted small">
+                                By
+                                <?php if ($plugin['author_url']): ?>
+                                <a href="<?= htmlspecialchars($plugin['author_url']) ?>" target="_blank" rel="noopener">
+                                    <?= htmlspecialchars($plugin['author']) ?>
+                                </a>
+                                <?php else: ?>
+                                <?= htmlspecialchars($plugin['author']) ?>
+                                <?php endif; ?>
+                            </div>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+
+                    <!-- Stats Row -->
+                    <div class="row text-center border-top border-bottom py-3 mb-4">
+                        <div class="col">
+                            <div class="h4 mb-0"><?= number_format($plugin['download_count']) ?></div>
+                            <div class="text-muted small">Downloads</div>
+                        </div>
+                        <div class="col">
+                            <div class="h4 mb-0">
+                                <?php if ($plugin['rating'] > 0): ?>
+                                <i class="bi bi-star-fill text-warning"></i>
+                                <?= number_format($plugin['rating'], 1) ?>
+                                <?php else: ?>
+                                <i class="bi bi-star text-muted"></i> --
+                                <?php endif; ?>
+                            </div>
+                            <div class="text-muted small">
+                                <?php if ($plugin['rating_count'] > 0): ?>
+                                <?= number_format($plugin['rating_count']) ?> rating<?= $plugin['rating_count'] !== 1 ? 's' : '' ?>
+                                <?php else: ?>
+                                No ratings yet
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                        <div class="col">
+                            <div class="h4 mb-0">v<?= htmlspecialchars($plugin['version']) ?></div>
+                            <div class="text-muted small">Version</div>
+                        </div>
+                    </div>
+
+                    <!-- Description -->
+                    <h3 class="h5">Description</h3>
+                    <div class="plugin-description mb-4">
+                        <?php if ($plugin['description']): ?>
+                        <?= nl2br(htmlspecialchars($plugin['description'])) ?>
+                        <?php else: ?>
+                        <p class="text-muted">No description available.</p>
+                        <?php endif; ?>
+                    </div>
+
+                    <!-- Tags -->
+                    <?php if (!empty($plugin['tags'])): ?>
+                    <h3 class="h5">Tags</h3>
+                    <div class="mb-4">
+                        <?php foreach ($plugin['tags'] as $tag): ?>
+                        <a href="/plugins?q=<?= urlencode($tag) ?>" class="badge bg-light text-dark text-decoration-none me-1 mb-1">
+                            <i class="bi bi-tag"></i> <?= htmlspecialchars($tag) ?>
+                        </a>
+                        <?php endforeach; ?>
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <!-- Related Plugins -->
+            <?php if (!empty($relatedPlugins)): ?>
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="h5 mb-0"><i class="bi bi-collection"></i> Related Plugins</h3>
+                </div>
+                <div class="card-body">
+                    <div class="row row-cols-1 row-cols-md-2 g-3">
+                        <?php foreach ($relatedPlugins as $related): ?>
+                        <div class="col">
+                            <div class="d-flex align-items-center p-2 border rounded hover-bg-light">
+                                <?php if ($related['icon_url']): ?>
+                                <img src="<?= htmlspecialchars($related['icon_url']) ?>"
+                                     alt="" class="me-3" style="width: 40px; height: 40px; object-fit: contain;">
+                                <?php else: ?>
+                                <div class="me-3 d-flex align-items-center justify-content-center bg-light rounded"
+                                     style="width: 40px; height: 40px;">
+                                    <i class="bi bi-puzzle text-muted"></i>
+                                </div>
+                                <?php endif; ?>
+                                <div class="flex-grow-1 min-width-0">
+                                    <a href="/plugins/view/<?= htmlspecialchars($related['slug']) ?>"
+                                       class="text-decoration-none fw-bold d-block text-truncate">
+                                        <?= htmlspecialchars($related['name']) ?>
+                                    </a>
+                                    <small class="text-muted d-block text-truncate">
+                                        <?= htmlspecialchars($related['short_description'] ?: 'No description') ?>
+                                    </small>
+                                </div>
+                            </div>
+                        </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+            <?php endif; ?>
+        </div>
+
+        <!-- Sidebar -->
+        <div class="col-lg-4">
+            <!-- Action Card -->
+            <div class="card mb-4">
+                <div class="card-body">
+                    <div class="d-grid gap-2">
+                        <?php if ($plugin['homepage_url']): ?>
+                        <a href="<?= htmlspecialchars($plugin['homepage_url']) ?>"
+                           class="btn btn-primary btn-lg" target="_blank" rel="noopener">
+                            <i class="bi bi-box-arrow-up-right"></i> Visit Homepage
+                        </a>
+                        <?php endif; ?>
+
+                        <?php if ($plugin['documentation_url']): ?>
+                        <a href="<?= htmlspecialchars($plugin['documentation_url']) ?>"
+                           class="btn btn-outline-primary" target="_blank" rel="noopener">
+                            <i class="bi bi-book"></i> Documentation
+                        </a>
+                        <?php endif; ?>
+
+                        <a href="/plugins?category=<?= urlencode($plugin['category']) ?>"
+                           class="btn btn-outline-secondary">
+                            <i class="bi bi-folder"></i> Browse <?= htmlspecialchars($plugin['category_name']) ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Info Card -->
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h3 class="h6 mb-0"><i class="bi bi-info-circle"></i> Plugin Information</h3>
+                </div>
+                <div class="card-body p-0">
+                    <table class="table table-sm table-borderless mb-0">
+                        <tr>
+                            <td class="text-muted ps-3">Version</td>
+                            <td class="pe-3"><?= htmlspecialchars($plugin['version']) ?></td>
+                        </tr>
+                        <tr>
+                            <td class="text-muted ps-3">Category</td>
+                            <td class="pe-3"><?= htmlspecialchars($plugin['category_name']) ?></td>
+                        </tr>
+                        <?php if ($plugin['author']): ?>
+                        <tr>
+                            <td class="text-muted ps-3">Author</td>
+                            <td class="pe-3">
+                                <?php if ($plugin['author_url']): ?>
+                                <a href="<?= htmlspecialchars($plugin['author_url']) ?>" target="_blank" rel="noopener">
+                                    <?= htmlspecialchars($plugin['author']) ?>
+                                </a>
+                                <?php else: ?>
+                                <?= htmlspecialchars($plugin['author']) ?>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <?php endif; ?>
+                        <tr>
+                            <td class="text-muted ps-3">Downloads</td>
+                            <td class="pe-3"><?= number_format($plugin['download_count']) ?></td>
+                        </tr>
+                        <tr>
+                            <td class="text-muted ps-3">Rating</td>
+                            <td class="pe-3">
+                                <?php if ($plugin['rating'] > 0): ?>
+                                <?= number_format($plugin['rating'], 1) ?>/5
+                                (<?= number_format($plugin['rating_count']) ?>)
+                                <?php else: ?>
+                                Not rated
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="text-muted ps-3">Added</td>
+                            <td class="pe-3">
+                                <?= date('M j, Y', strtotime($plugin['created_at'])) ?>
+                            </td>
+                        </tr>
+                        <?php if ($plugin['updated_at']): ?>
+                        <tr>
+                            <td class="text-muted ps-3">Updated</td>
+                            <td class="pe-3">
+                                <?= date('M j, Y', strtotime($plugin['updated_at'])) ?>
+                            </td>
+                        </tr>
+                        <?php endif; ?>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Search Widget -->
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="h6 mb-0"><i class="bi bi-search"></i> Search Plugins</h3>
+                </div>
+                <div class="card-body">
+                    <form method="GET" action="/plugins">
+                        <div class="input-group">
+                            <input type="text" class="form-control" name="q"
+                                   placeholder="Search plugins...">
+                            <button class="btn btn-primary" type="submit">
+                                <i class="bi bi-search"></i>
+                            </button>
+                        </div>
+                    </form>
+
+                    <div class="mt-3">
+                        <small class="text-muted">Browse by category:</small>
+                        <div class="d-flex flex-wrap gap-1 mt-2">
+                            <?php foreach ($categories as $key => $name): ?>
+                            <a href="/plugins?category=<?= urlencode($key) ?>"
+                               class="badge bg-<?= getCategoryBadgeClass($key) ?> text-decoration-none">
+                                <?= htmlspecialchars($name) ?>
+                            </a>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+// Helper function for category badge colors
+function getCategoryBadgeClass($category) {
+    $classes = [
+        'general' => 'secondary',
+        'automation' => 'primary',
+        'integration' => 'info',
+        'analytics' => 'success',
+        'security' => 'danger',
+        'development' => 'dark',
+        'productivity' => 'warning',
+        'communication' => 'purple'
+    ];
+    return $classes[$category] ?? 'secondary';
+}
+?>
+
+<style>
+.plugin-description {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+.hover-bg-light:hover {
+    background-color: #f8f9fa;
+}
+
+.min-width-0 {
+    min-width: 0;
+}
+
+.bg-purple {
+    background-color: #6f42c1 !important;
+    color: white;
+}
+</style>


### PR DESCRIPTION
## Summary

Implements plugin search functionality for the Plugin Registry and Discovery epic, allowing users to find plugins by name, description, and tags.

### Changes

**New Files:**
- `controls/Plugins.php` - Plugin controller with search, autocomplete, and view endpoints
- `services/PluginSearchService.php` - Search service with relevance ranking algorithm
- `views/plugins/index.php` - Plugin listing with search box and autocomplete UI
- `views/plugins/view.php` - Plugin detail view with related plugins

**Modified Files:**
- `sql/tenant_schema.sql` - Added plugins table with FULLTEXT index and authcontrol entries

### Features Implemented

1. **Search with Relevance Ranking**
   - Exact name match: 100 points
   - Name contains: 80 points
   - Description contains: 50 points
   - Tags contain: 30 points
   - Results sorted by relevance score

2. **No-Results Handling**
   - Helpful tips for better searches
   - Alternative search term suggestions
   - Popular categories with counts
   - Popular plugins recommendations

3. **Autocomplete**
   - 300ms debounce to prevent excessive API calls
   - Minimum 2 characters to trigger
   - Maximum 8 suggestions returned
   - Keyboard navigation support (arrows, enter, escape)

### Security

- All endpoints require authentication
- Input sanitization on all search terms
- Parameterized SQL queries to prevent injection
- XSS protection with HTML escaping

## Test Plan

- [ ] Navigate to /plugins and verify the search box appears
- [ ] Search for a plugin name and verify results are ranked by relevance
- [ ] Search with no matching results and verify helpful suggestions appear
- [ ] Type partial plugin name and verify autocomplete suggestions appear
- [ ] Verify autocomplete has 300ms debounce
- [ ] Click on a plugin to view its detail page

Closes #102