### PR TITLE
feat: implement plugin category and tag browsing (#103)

### DIFF
--- a/controls/Plugins.php
+++ b/controls/Plugins.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Plugins Controller
+ *
+ * Handles plugin registry browsing, category filtering, and tag-based discovery.
+ * Public access (level 101) - no login required for browsing.
+ */
+
+namespace app;
+
+use \Flight as Flight;
+use \RedBeanPHP\R as R;
+use \Exception as Exception;
+
+require_once __DIR__ . '/../services/PluginRegistryService.php';
+
+use \app\services\PluginRegistryService;
+
+class Plugins extends BaseControls\Control {
+
+    /**
+     * Main plugin registry - browse all plugins
+     * Route: /plugins
+     */
+    public function index() {
+        // Get filter parameters from query string
+        $categorySlug = $this->getParam('category');
+        $tagSlugs = $this->getParam('tags');
+        $search = $this->getParam('search');
+        $sort = $this->getParam('sort', 'downloads');
+        $page = max(1, (int) $this->getParam('page', 1));
+        $perPage = 12;
+
+        // Parse tag slugs from comma-separated string
+        $selectedTags = [];
+        if (!empty($tagSlugs)) {
+            $selectedTags = array_filter(array_map('trim', explode(',', $tagSlugs)));
+        }
+
+        // Build filters
+        $filters = [
+            'sort' => $sort,
+            'limit' => $perPage,
+            'offset' => ($page - 1) * $perPage
+        ];
+
+        if (!empty($categorySlug)) {
+            $filters['category_slug'] = $categorySlug;
+        }
+
+        if (!empty($selectedTags)) {
+            $filters['tag_slugs'] = $selectedTags;
+        }
+
+        if (!empty($search)) {
+            $filters['search'] = $search;
+        }
+
+        // Get plugins with filters
+        $result = PluginRegistryService::getPlugins($filters);
+        $plugins = $result['plugins'];
+        $totalPlugins = $result['total'];
+        $totalPages = ceil($totalPlugins / $perPage);
+
+        // Get categories for sidebar
+        $categories = PluginRegistryService::getCategories();
+
+        // Get tag counts based on current category/search filters
+        $tagFilters = [];
+        if (!empty($categorySlug)) {
+            $tagFilters['category_slug'] = $categorySlug;
+        }
+        if (!empty($search)) {
+            $tagFilters['search'] = $search;
+        }
+        $tags = PluginRegistryService::getTagCountsForFilters($tagFilters);
+
+        // Get featured plugins for sidebar (only on first page with no filters)
+        $featuredPlugins = [];
+        if ($page === 1 && empty($categorySlug) && empty($selectedTags) && empty($search)) {
+            $featuredPlugins = PluginRegistryService::getFeaturedPlugins(3);
+        }
+
+        // Get current category details if filtering by category
+        $currentCategory = null;
+        if (!empty($categorySlug)) {
+            $currentCategory = PluginRegistryService::getCategoryBySlug($categorySlug);
+        }
+
+        // Get statistics
+        $stats = PluginRegistryService::getStats();
+
+        $this->render('plugins/index', [
+            'title' => $currentCategory ? 'Plugins - ' . $currentCategory->name : 'Plugin Registry',
+            'plugins' => $plugins,
+            'categories' => $categories,
+            'tags' => $tags,
+            'featuredPlugins' => $featuredPlugins,
+            'currentCategory' => $currentCategory,
+            'selectedTags' => $selectedTags,
+            'search' => $search,
+            'sort' => $sort,
+            'page' => $page,
+            'totalPages' => $totalPages,
+            'totalPlugins' => $totalPlugins,
+            'perPage' => $perPage,
+            'stats' => $stats
+        ]);
+    }
+
+    /**
+     * Browse plugins by category
+     * Route: /plugins/category/{slug}
+     *
+     * @param array $params Route parameters
+     */
+    public function category($params = []) {
+        // Get category slug from URL
+        $slug = $params['operation']->name ?? $this->getParam('slug');
+
+        if (empty($slug)) {
+            Flight::redirect('/plugins');
+            return;
+        }
+
+        // Get category
+        $category = PluginRegistryService::getCategoryBySlug($slug);
+        if (!$category) {
+            $this->flash('error', 'Category not found');
+            Flight::redirect('/plugins');
+            return;
+        }
+
+        // Get filter parameters
+        $tagSlugs = $this->getParam('tags');
+        $search = $this->getParam('search');
+        $sort = $this->getParam('sort', 'downloads');
+        $page = max(1, (int) $this->getParam('page', 1));
+        $perPage = 12;
+
+        // Parse tag slugs
+        $selectedTags = [];
+        if (!empty($tagSlugs)) {
+            $selectedTags = array_filter(array_map('trim', explode(',', $tagSlugs)));
+        }
+
+        // Build filters
+        $filters = [
+            'category_id' => $category->id,
+            'sort' => $sort,
+            'limit' => $perPage,
+            'offset' => ($page - 1) * $perPage
+        ];
+
+        if (!empty($selectedTags)) {
+            $filters['tag_slugs'] = $selectedTags;
+        }
+
+        if (!empty($search)) {
+            $filters['search'] = $search;
+        }
+
+        // Get plugins
+        $result = PluginRegistryService::getPlugins($filters);
+        $plugins = $result['plugins'];
+        $totalPlugins = $result['total'];
+        $totalPages = ceil($totalPlugins / $perPage);
+
+        // Get all categories for sidebar
+        $categories = PluginRegistryService::getCategories();
+
+        // Get subcategories if this is a parent category
+        $subcategories = PluginRegistryService::getSubcategories($category->id);
+
+        // Get tag counts for this category
+        $tags = PluginRegistryService::getTagCountsForFilters([
+            'category_id' => $category->id,
+            'search' => $search
+        ]);
+
+        $this->render('plugins/category', [
+            'title' => 'Plugins - ' . $category->name,
+            'category' => $category,
+            'subcategories' => $subcategories,
+            'plugins' => $plugins,
+            'categories' => $categories,
+            'tags' => $tags,
+            'selectedTags' => $selectedTags,
+            'search' => $search,
+            'sort' => $sort,
+            'page' => $page,
+            'totalPages' => $totalPages,
+            'totalPlugins' => $totalPlugins,
+            'perPage' => $perPage
+        ]);
+    }
+
+    /**
+     * View plugin details
+     * Route: /plugins/view/{slug}
+     *
+     * @param array $params Route parameters
+     */
+    public function view($params = []) {
+        // Get plugin slug from URL
+        $slug = $params['operation']->name ?? $this->getParam('slug');
+
+        if (empty($slug)) {
+            Flight::redirect('/plugins');
+            return;
+        }
+
+        // Get plugin details
+        $plugin = PluginRegistryService::getPluginBySlug($slug);
+        if (!$plugin) {
+            $this->flash('error', 'Plugin not found');
+            Flight::redirect('/plugins');
+            return;
+        }
+
+        // Get related plugins (same category)
+        $relatedPlugins = [];
+        if (!empty($plugin['category_id'])) {
+            $result = PluginRegistryService::getPlugins([
+                'category_id' => $plugin['category_id'],
+                'limit' => 4
+            ]);
+            // Filter out current plugin
+            $relatedPlugins = array_filter($result['plugins'], function($p) use ($plugin) {
+                return $p['id'] !== $plugin['id'];
+            });
+            $relatedPlugins = array_slice($relatedPlugins, 0, 3);
+        }
+
+        $this->render('plugins/view', [
+            'title' => $plugin['name'] . ' - Plugin Registry',
+            'plugin' => $plugin,
+            'relatedPlugins' => $relatedPlugins
+        ]);
+    }
+
+    /**
+     * Search plugins (AJAX endpoint)
+     * Route: /plugins/search
+     */
+    public function search() {
+        $search = $this->getParam('q', '');
+        $categorySlug = $this->getParam('category');
+        $tagSlugs = $this->getParam('tags');
+        $limit = min(max((int) $this->getParam('limit', 10), 1), 50);
+
+        // Parse tag slugs
+        $selectedTags = [];
+        if (!empty($tagSlugs)) {
+            $selectedTags = array_filter(array_map('trim', explode(',', $tagSlugs)));
+        }
+
+        // Build filters
+        $filters = [
+            'search' => $search,
+            'limit' => $limit
+        ];
+
+        if (!empty($categorySlug)) {
+            $filters['category_slug'] = $categorySlug;
+        }
+
+        if (!empty($selectedTags)) {
+            $filters['tag_slugs'] = $selectedTags;
+        }
+
+        $result = PluginRegistryService::getPlugins($filters);
+
+        $this->jsonSuccess([
+            'plugins' => $result['plugins'],
+            'total' => $result['total']
+        ]);
+    }
+
+    /**
+     * Get filter counts (AJAX endpoint)
+     * Route: /plugins/filters
+     */
+    public function filters() {
+        $categorySlug = $this->getParam('category');
+        $search = $this->getParam('search');
+
+        $filters = [];
+        if (!empty($categorySlug)) {
+            $filters['category_slug'] = $categorySlug;
+        }
+        if (!empty($search)) {
+            $filters['search'] = $search;
+        }
+
+        $tags = PluginRegistryService::getTagCountsForFilters($filters);
+        $categories = PluginRegistryService::getCategoryCounts();
+
+        $this->jsonSuccess([
+            'tags' => $tags,
+            'categories' => $categories
+        ]);
+    }
+}

--- a/services/PluginRegistryService.php
+++ b/services/PluginRegistryService.php
@@ -1,0 +1,499 @@
+<?php
+/**
+ * Plugin Registry Service
+ *
+ * Handles plugin discovery, category browsing, and tag filtering.
+ * Provides methods for retrieving plugins organized by categories and tags.
+ */
+
+namespace app\services;
+
+use \RedBeanPHP\R as R;
+
+class PluginRegistryService {
+
+    // ==================== Categories ====================
+
+    /**
+     * Get all categories with plugin counts
+     *
+     * @param bool $includeEmpty Include categories with no plugins
+     * @return array
+     */
+    public static function getCategories(bool $includeEmpty = false): array {
+        $sql = ' ORDER BY display_order ASC, name ASC ';
+        if (!$includeEmpty) {
+            $sql = ' plugin_count > 0 ' . $sql;
+        }
+        return array_values(R::findAll('plugincategory', $sql));
+    }
+
+    /**
+     * Get a category by slug
+     *
+     * @param string $slug Category slug
+     * @return \RedBeanPHP\OODBBean|null
+     */
+    public static function getCategoryBySlug(string $slug) {
+        return R::findOne('plugincategory', ' slug = ? ', [$slug]);
+    }
+
+    /**
+     * Get a category by ID
+     *
+     * @param int $id Category ID
+     * @return \RedBeanPHP\OODBBean|null
+     */
+    public static function getCategory(int $id) {
+        $category = R::load('plugincategory', $id);
+        return $category->id ? $category : null;
+    }
+
+    /**
+     * Get subcategories for a parent category
+     *
+     * @param int $parentId Parent category ID
+     * @return array
+     */
+    public static function getSubcategories(int $parentId): array {
+        return array_values(R::find('plugincategory',
+            ' parent_id = ? ORDER BY display_order ASC, name ASC ',
+            [$parentId]
+        ));
+    }
+
+    // ==================== Tags ====================
+
+    /**
+     * Get all tags with plugin counts
+     *
+     * @param bool $includeEmpty Include tags with no plugins
+     * @return array
+     */
+    public static function getTags(bool $includeEmpty = false): array {
+        $sql = ' ORDER BY plugin_count DESC, name ASC ';
+        if (!$includeEmpty) {
+            $sql = ' plugin_count > 0 ' . $sql;
+        }
+        return array_values(R::findAll('plugintag', $sql));
+    }
+
+    /**
+     * Get a tag by slug
+     *
+     * @param string $slug Tag slug
+     * @return \RedBeanPHP\OODBBean|null
+     */
+    public static function getTagBySlug(string $slug) {
+        return R::findOne('plugintag', ' slug = ? ', [$slug]);
+    }
+
+    /**
+     * Get tags for a specific plugin
+     *
+     * @param int $pluginId Plugin ID
+     * @return array
+     */
+    public static function getPluginTags(int $pluginId): array {
+        return R::getAll(
+            'SELECT t.* FROM plugintag t ' .
+            'INNER JOIN plugin_plugintag pt ON t.id = pt.plugintag_id ' .
+            'WHERE pt.plugin_id = ? ORDER BY t.name ASC',
+            [$pluginId]
+        );
+    }
+
+    /**
+     * Get multiple tags by their slugs
+     *
+     * @param array $slugs Tag slugs
+     * @return array
+     */
+    public static function getTagsBySlugs(array $slugs): array {
+        if (empty($slugs)) {
+            return [];
+        }
+        $placeholders = implode(',', array_fill(0, count($slugs), '?'));
+        return R::getAll(
+            'SELECT * FROM plugintag WHERE slug IN (' . $placeholders . ') ORDER BY name ASC',
+            $slugs
+        );
+    }
+
+    // ==================== Plugins ====================
+
+    /**
+     * Get plugins with filtering options
+     *
+     * @param array $filters Filter options
+     * @return array
+     */
+    public static function getPlugins(array $filters = []): array {
+        // Build query components
+        $queryData = self::buildPluginQuery($filters);
+
+        // Count total results
+        $countResult = R::getRow($queryData['countSql'], $queryData['countParams']);
+        $total = (int) ($countResult['total'] ?? 0);
+
+        // Get plugins
+        $plugins = R::getAll($queryData['selectSql'], $queryData['selectParams']);
+
+        // Enrich plugins with tags
+        foreach ($plugins as $key => $plugin) {
+            $plugins[$key]['tags'] = self::getPluginTags((int) $plugin['id']);
+        }
+
+        return [
+            'plugins' => $plugins,
+            'total' => $total,
+            'limit' => $queryData['limit'],
+            'offset' => $queryData['offset']
+        ];
+    }
+
+    /**
+     * Build plugin query components
+     *
+     * @param array $filters Filter options
+     * @return array Query components
+     */
+    private static function buildPluginQuery(array $filters): array {
+        $conditions = ['p.is_active = 1'];
+        $params = [];
+        $useTagJoin = false;
+        $useCategoryJoin = false;
+
+        // Filter by category ID
+        if (!empty($filters['category_id'])) {
+            $conditions[] = 'p.category_id = ?';
+            $params[] = (int) $filters['category_id'];
+        }
+
+        // Filter by category slug
+        if (!empty($filters['category_slug'])) {
+            $useCategoryJoin = true;
+            $conditions[] = 'cat.slug = ?';
+            $params[] = $filters['category_slug'];
+        }
+
+        // Filter by tag slugs (must match ALL tags)
+        $tagSubquery = '';
+        $tagParams = [];
+        if (!empty($filters['tag_slugs']) && is_array($filters['tag_slugs'])) {
+            $tagSlugs = array_values($filters['tag_slugs']);
+            $tagCount = count($tagSlugs);
+            $tagPlaceholders = implode(',', array_fill(0, $tagCount, '?'));
+            $tagParams = array_merge($tagSlugs, [$tagCount]);
+            $useTagJoin = true;
+        }
+
+        // Search in name and description
+        if (!empty($filters['search'])) {
+            $searchTerm = '%' . $filters['search'] . '%';
+            $conditions[] = '(p.name LIKE ? OR p.short_description LIKE ? OR p.description LIKE ?)';
+            $params[] = $searchTerm;
+            $params[] = $searchTerm;
+            $params[] = $searchTerm;
+        }
+
+        // Featured only
+        if (!empty($filters['is_featured'])) {
+            $conditions[] = 'p.is_featured = 1';
+        }
+
+        // Sorting - whitelist approach
+        $sortOptions = [
+            'downloads' => 'p.downloads DESC',
+            'downloads_asc' => 'p.downloads ASC',
+            'rating' => 'p.rating DESC',
+            'rating_asc' => 'p.rating ASC',
+            'name' => 'p.name ASC',
+            'name_desc' => 'p.name DESC',
+            'created_at' => 'p.created_at DESC',
+            'created_at_asc' => 'p.created_at ASC'
+        ];
+
+        $sortKey = 'downloads';
+        if (!empty($filters['sort'])) {
+            $requestedSort = $filters['sort'];
+            if (!empty($filters['order']) && strtolower($filters['order']) === 'asc') {
+                $requestedSort .= '_asc';
+            }
+            if (isset($sortOptions[$requestedSort])) {
+                $sortKey = $requestedSort;
+            } elseif (isset($sortOptions[$filters['sort']])) {
+                $sortKey = $filters['sort'];
+            }
+        }
+        $orderBy = $sortOptions[$sortKey];
+
+        // Pagination
+        $limit = min(max((int) ($filters['limit'] ?? 20), 1), 100);
+        $offset = max((int) ($filters['offset'] ?? 0), 0);
+
+        // Build SQL parts
+        $whereClause = implode(' AND ', $conditions);
+
+        // Category join
+        $categoryJoin = $useCategoryJoin
+            ? 'INNER JOIN plugincategory cat ON p.category_id = cat.id'
+            : 'LEFT JOIN plugincategory pc ON p.category_id = pc.id';
+
+        // Tag filter join
+        $tagJoin = '';
+        if ($useTagJoin && !empty($tagParams)) {
+            $tagPlaceholders = implode(',', array_fill(0, count($tagParams) - 1, '?'));
+            $tagJoin = 'INNER JOIN (' .
+                'SELECT pt.plugin_id FROM plugin_plugintag pt ' .
+                'INNER JOIN plugintag t ON pt.plugintag_id = t.id ' .
+                'WHERE t.slug IN (' . $tagPlaceholders . ') ' .
+                'GROUP BY pt.plugin_id HAVING COUNT(DISTINCT pt.plugintag_id) = ?' .
+                ') tf ON p.id = tf.plugin_id';
+        }
+
+        // Build count query
+        $countParams = $useTagJoin ? array_merge($tagParams, $params) : $params;
+        $countSql = 'SELECT COUNT(DISTINCT p.id) as total FROM plugin p ' .
+            ($useTagJoin ? $tagJoin . ' ' : '') .
+            ($useCategoryJoin ? $categoryJoin . ' ' : '') .
+            'WHERE ' . $whereClause;
+
+        // Build select query
+        $selectParams = $useTagJoin ? array_merge($tagParams, $params, [$limit, $offset]) : array_merge($params, [$limit, $offset]);
+
+        $selectSql = 'SELECT DISTINCT p.*, ' .
+            'COALESCE(pc.name, cat.name) as category_name, ' .
+            'COALESCE(pc.slug, cat.slug) as category_slug, ' .
+            'COALESCE(pc.icon, cat.icon) as category_icon ' .
+            'FROM plugin p ' .
+            ($useTagJoin ? $tagJoin . ' ' : '') .
+            $categoryJoin . ' ' .
+            'WHERE ' . $whereClause . ' ' .
+            'ORDER BY ' . $orderBy . ' ' .
+            'LIMIT ? OFFSET ?';
+
+        return [
+            'countSql' => $countSql,
+            'countParams' => $countParams,
+            'selectSql' => $selectSql,
+            'selectParams' => $selectParams,
+            'limit' => $limit,
+            'offset' => $offset
+        ];
+    }
+
+    /**
+     * Get a plugin by slug with full details
+     *
+     * @param string $slug Plugin slug
+     * @return array|null
+     */
+    public static function getPluginBySlug(string $slug): ?array {
+        $plugin = R::getRow(
+            'SELECT p.*, pc.name as category_name, pc.slug as category_slug, pc.icon as category_icon ' .
+            'FROM plugin p LEFT JOIN plugincategory pc ON p.category_id = pc.id ' .
+            'WHERE p.slug = ? AND p.is_active = 1',
+            [$slug]
+        );
+
+        if (!$plugin) {
+            return null;
+        }
+
+        $plugin['tags'] = self::getPluginTags((int) $plugin['id']);
+        return $plugin;
+    }
+
+    /**
+     * Get a plugin by ID with full details
+     *
+     * @param int $id Plugin ID
+     * @return array|null
+     */
+    public static function getPlugin(int $id): ?array {
+        $plugin = R::getRow(
+            'SELECT p.*, pc.name as category_name, pc.slug as category_slug, pc.icon as category_icon ' .
+            'FROM plugin p LEFT JOIN plugincategory pc ON p.category_id = pc.id ' .
+            'WHERE p.id = ? AND p.is_active = 1',
+            [$id]
+        );
+
+        if (!$plugin) {
+            return null;
+        }
+
+        $plugin['tags'] = self::getPluginTags($id);
+        return $plugin;
+    }
+
+    /**
+     * Get featured plugins
+     *
+     * @param int $limit Max plugins to return
+     * @return array
+     */
+    public static function getFeaturedPlugins(int $limit = 6): array {
+        $result = self::getPlugins([
+            'is_featured' => true,
+            'sort' => 'downloads',
+            'limit' => $limit
+        ]);
+        return $result['plugins'];
+    }
+
+    /**
+     * Get popular plugins (by downloads)
+     *
+     * @param int $limit Max plugins to return
+     * @return array
+     */
+    public static function getPopularPlugins(int $limit = 6): array {
+        $result = self::getPlugins([
+            'sort' => 'downloads',
+            'order' => 'desc',
+            'limit' => $limit
+        ]);
+        return $result['plugins'];
+    }
+
+    /**
+     * Get plugins in a category
+     *
+     * @param int $categoryId Category ID
+     * @param array $filters Additional filters
+     * @return array
+     */
+    public static function getPluginsByCategory(int $categoryId, array $filters = []): array {
+        $filters['category_id'] = $categoryId;
+        return self::getPlugins($filters);
+    }
+
+    /**
+     * Get plugins by tag(s)
+     *
+     * @param array $tagSlugs Tag slugs
+     * @param array $filters Additional filters
+     * @return array
+     */
+    public static function getPluginsByTags(array $tagSlugs, array $filters = []): array {
+        $filters['tag_slugs'] = $tagSlugs;
+        return self::getPlugins($filters);
+    }
+
+    // ==================== Statistics ====================
+
+    /**
+     * Get plugin registry statistics
+     *
+     * @return array
+     */
+    public static function getStats(): array {
+        return [
+            'total_plugins' => R::count('plugin', ' is_active = 1 '),
+            'total_categories' => R::count('plugincategory'),
+            'total_tags' => R::count('plugintag'),
+            'featured_count' => R::count('plugin', ' is_active = 1 AND is_featured = 1 '),
+            'total_downloads' => (int) R::getCell('SELECT SUM(downloads) FROM plugin WHERE is_active = 1')
+        ];
+    }
+
+    // ==================== Filter Counts ====================
+
+    /**
+     * Get tag counts for a set of plugins (for filter display)
+     *
+     * @param array $filters Current filters (excluding tags)
+     * @return array Tag data with counts
+     */
+    public static function getTagCountsForFilters(array $filters = []): array {
+        // Remove tag filters to get base plugin set
+        unset($filters['tag_ids'], $filters['tag_slugs']);
+
+        $conditions = ['p.is_active = 1'];
+        $params = [];
+
+        // Filter by category ID
+        if (!empty($filters['category_id'])) {
+            $conditions[] = 'p.category_id = ?';
+            $params[] = (int) $filters['category_id'];
+        }
+
+        // Filter by category slug
+        if (!empty($filters['category_slug'])) {
+            $conditions[] = 'c.slug = ?';
+            $params[] = $filters['category_slug'];
+        }
+
+        // Search
+        if (!empty($filters['search'])) {
+            $searchTerm = '%' . $filters['search'] . '%';
+            $conditions[] = '(p.name LIKE ? OR p.short_description LIKE ? OR p.description LIKE ?)';
+            $params[] = $searchTerm;
+            $params[] = $searchTerm;
+            $params[] = $searchTerm;
+        }
+
+        $whereClause = implode(' AND ', $conditions);
+
+        $useCategoryJoin = !empty($filters['category_slug']);
+        $categoryJoin = $useCategoryJoin ? 'INNER JOIN plugincategory c ON p.category_id = c.id ' : '';
+
+        $sql = 'SELECT t.id, t.name, t.slug, COUNT(DISTINCT pt.plugin_id) as count ' .
+            'FROM plugintag t ' .
+            'INNER JOIN plugin_plugintag pt ON t.id = pt.plugintag_id ' .
+            'INNER JOIN plugin p ON pt.plugin_id = p.id ' .
+            $categoryJoin .
+            'WHERE ' . $whereClause . ' ' .
+            'GROUP BY t.id, t.name, t.slug ' .
+            'HAVING count > 0 ' .
+            'ORDER BY count DESC, t.name ASC';
+
+        return R::getAll($sql, $params);
+    }
+
+    /**
+     * Get category counts (plugins per category)
+     *
+     * @return array
+     */
+    public static function getCategoryCounts(): array {
+        return R::getAll(
+            'SELECT c.id, c.name, c.slug, c.icon, c.plugin_count as count ' .
+            'FROM plugincategory c WHERE c.plugin_count > 0 ' .
+            'ORDER BY c.display_order ASC, c.name ASC'
+        );
+    }
+
+    // ==================== Cache Management ====================
+
+    /**
+     * Recalculate and update plugin counts for categories
+     */
+    public static function updateCategoryCounts(): void {
+        R::exec(
+            'UPDATE plugincategory pc SET plugin_count = (' .
+            'SELECT COUNT(*) FROM plugin p WHERE p.category_id = pc.id AND p.is_active = 1)'
+        );
+    }
+
+    /**
+     * Recalculate and update plugin counts for tags
+     */
+    public static function updateTagCounts(): void {
+        R::exec(
+            'UPDATE plugintag pt SET plugin_count = (' .
+            'SELECT COUNT(DISTINCT pp.plugin_id) FROM plugin_plugintag pp ' .
+            'INNER JOIN plugin p ON pp.plugin_id = p.id ' .
+            'WHERE pp.plugintag_id = pt.id AND p.is_active = 1)'
+        );
+    }
+
+    /**
+     * Recalculate all counts
+     */
+    public static function updateAllCounts(): void {
+        self::updateCategoryCounts();
+        self::updateTagCounts();
+    }
+}

--- a/sql/tenant_schema.sql
+++ b/sql/tenant_schema.sql
@@ -667,4 +667,180 @@ INSERT INTO `authcontrol` (`control`, `method`, `level`, `description`) VALUES
 ('webhook', 'mailgun', 101, 'Mailgun incoming email webhook')
 ON DUPLICATE KEY UPDATE `level` = VALUES(`level`);
 
+-- ============================================================================
+-- PLUGIN REGISTRY TABLES
+-- ============================================================================
+
+-- Plugin categories for organizing plugins
+CREATE TABLE IF NOT EXISTS `plugincategory` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `name` VARCHAR(100) NOT NULL,
+    `slug` VARCHAR(100) NOT NULL UNIQUE,
+    `description` TEXT,
+    `parent_id` INT DEFAULT NULL,
+    `icon` VARCHAR(50) DEFAULT 'bi-puzzle',
+    `plugin_count` INT DEFAULT 0,
+    `display_order` INT DEFAULT 0,
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME ON UPDATE CURRENT_TIMESTAMP,
+    INDEX `idx_slug` (`slug`),
+    INDEX `idx_parent` (`parent_id`),
+    INDEX `idx_display_order` (`display_order`),
+    FOREIGN KEY (`parent_id`) REFERENCES `plugincategory`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Plugin tags for filtering
+CREATE TABLE IF NOT EXISTS `plugintag` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `name` VARCHAR(50) NOT NULL,
+    `slug` VARCHAR(50) NOT NULL UNIQUE,
+    `plugin_count` INT DEFAULT 0,
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX `idx_slug` (`slug`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Plugins in the registry
+CREATE TABLE IF NOT EXISTS `plugin` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `name` VARCHAR(100) NOT NULL,
+    `slug` VARCHAR(100) NOT NULL UNIQUE,
+    `description` TEXT,
+    `short_description` VARCHAR(255),
+    `version` VARCHAR(20),
+    `author` VARCHAR(100),
+    `author_url` VARCHAR(255),
+    `icon` VARCHAR(100) DEFAULT 'bi-puzzle-fill',
+    `category_id` INT,
+    `is_active` TINYINT(1) DEFAULT 1,
+    `is_featured` TINYINT(1) DEFAULT 0,
+    `downloads` INT DEFAULT 0,
+    `rating` DECIMAL(2,1) DEFAULT 0.0,
+    `rating_count` INT DEFAULT 0,
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME ON UPDATE CURRENT_TIMESTAMP,
+    INDEX `idx_slug` (`slug`),
+    INDEX `idx_category` (`category_id`),
+    INDEX `idx_active` (`is_active`),
+    INDEX `idx_featured` (`is_featured`),
+    INDEX `idx_downloads` (`downloads` DESC),
+    FOREIGN KEY (`category_id`) REFERENCES `plugincategory`(`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Plugin-tag relationship (many-to-many)
+CREATE TABLE IF NOT EXISTS `plugin_plugintag` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `plugin_id` INT NOT NULL,
+    `plugintag_id` INT NOT NULL,
+    UNIQUE KEY `uk_plugin_tag` (`plugin_id`, `plugintag_id`),
+    FOREIGN KEY (`plugin_id`) REFERENCES `plugin`(`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`plugintag_id`) REFERENCES `plugintag`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed plugin categories
+INSERT INTO `plugincategory` (`name`, `slug`, `description`, `icon`, `display_order`) VALUES
+('User Interface', 'ui', 'Plugins for enhancing user interfaces, themes, and visual components', 'bi-palette', 1),
+('Database', 'database', 'Database connectors, ORM extensions, and data management tools', 'bi-database', 2),
+('Integration', 'integration', 'Third-party service integrations and API connectors', 'bi-plug', 3),
+('Authentication', 'authentication', 'Security, authentication, and authorization plugins', 'bi-shield-lock', 4),
+('Analytics', 'analytics', 'Analytics, reporting, and data visualization tools', 'bi-graph-up', 5),
+('Utilities', 'utilities', 'General-purpose utility libraries and helper tools', 'bi-tools', 6)
+ON DUPLICATE KEY UPDATE `name` = VALUES(`name`);
+
+-- Seed plugin tags
+INSERT INTO `plugintag` (`name`, `slug`) VALUES
+('PHP', 'php'),
+('JavaScript', 'javascript'),
+('API', 'api'),
+('Frontend', 'frontend'),
+('Backend', 'backend'),
+('Security', 'security'),
+('Performance', 'performance'),
+('Caching', 'caching'),
+('REST', 'rest'),
+('OAuth', 'oauth')
+ON DUPLICATE KEY UPDATE `name` = VALUES(`name`);
+
+-- Seed sample plugins
+INSERT INTO `plugin` (`name`, `slug`, `short_description`, `description`, `version`, `author`, `icon`, `category_id`, `is_featured`, `downloads`) VALUES
+('Bootstrap Theme Pack', 'bootstrap-theme-pack', 'Collection of Bootstrap 5 themes and components', 'A comprehensive collection of professionally designed Bootstrap 5 themes, components, and UI kits for rapid development.', '2.1.0', 'ThemeCraft', 'bi-brush', 1, 1, 1250),
+('Redis Cache Driver', 'redis-cache-driver', 'High-performance Redis caching for FlightPHP', 'Seamlessly integrate Redis caching into your FlightPHP application for improved performance and scalability.', '1.5.2', 'CacheWorks', 'bi-lightning', 2, 0, 890),
+('Slack Notifier', 'slack-notifier', 'Send notifications to Slack channels', 'Easy-to-use Slack integration for sending notifications, alerts, and messages from your application.', '3.0.1', 'IntegratePro', 'bi-slack', 3, 1, 2100),
+('JWT Authentication', 'jwt-authentication', 'Secure JWT-based authentication system', 'Complete JWT authentication solution with token refresh, blacklisting, and role-based access control.', '2.0.0', 'SecureAuth', 'bi-key', 4, 1, 3200),
+('Google Analytics Bridge', 'google-analytics-bridge', 'Google Analytics 4 integration', 'Track user behavior and generate reports with seamless Google Analytics 4 integration.', '1.2.0', 'AnalyticsPro', 'bi-bar-chart', 5, 0, 780),
+('Form Validator', 'form-validator', 'Comprehensive form validation library', 'Powerful server-side and client-side form validation with customizable rules and error messages.', '4.1.0', 'FormMaster', 'bi-check-square', 6, 1, 1560),
+('MySQL Query Builder', 'mysql-query-builder', 'Fluent MySQL query builder for RedBeanPHP', 'Extend RedBeanPHP with a fluent query builder interface for complex MySQL queries.', '1.8.0', 'DBTools', 'bi-database-gear', 2, 0, 1100),
+('OAuth2 Server', 'oauth2-server', 'Full OAuth2 server implementation', 'Complete OAuth2 server with support for all grant types and token management.', '2.3.0', 'SecureAuth', 'bi-shield-check', 4, 0, 950),
+('Chart.js Dashboard', 'chartjs-dashboard', 'Interactive dashboard components', 'Beautiful, responsive dashboard components using Chart.js for data visualization.', '1.4.2', 'ChartWorks', 'bi-pie-chart', 5, 1, 1890),
+('Email Queue', 'email-queue', 'Async email queue with retry logic', 'Reliable email delivery with queue management, retry logic, and delivery tracking.', '2.0.1', 'MailPro', 'bi-envelope', 6, 0, 670)
+ON DUPLICATE KEY UPDATE `name` = VALUES(`name`);
+
+-- Link plugins to tags (after plugins are inserted)
+-- Bootstrap Theme Pack: frontend, javascript
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'bootstrap-theme-pack' AND t.slug IN ('frontend', 'javascript')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- Redis Cache Driver: backend, php, caching, performance
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'redis-cache-driver' AND t.slug IN ('backend', 'php', 'caching', 'performance')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- Slack Notifier: api, backend, rest
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'slack-notifier' AND t.slug IN ('api', 'backend', 'rest')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- JWT Authentication: security, backend, php, api
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'jwt-authentication' AND t.slug IN ('security', 'backend', 'php', 'api')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- Google Analytics Bridge: javascript, frontend, api
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'google-analytics-bridge' AND t.slug IN ('javascript', 'frontend', 'api')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- Form Validator: php, frontend, javascript
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'form-validator' AND t.slug IN ('php', 'frontend', 'javascript')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- MySQL Query Builder: php, backend
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'mysql-query-builder' AND t.slug IN ('php', 'backend')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- OAuth2 Server: security, oauth, api, php
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'oauth2-server' AND t.slug IN ('security', 'oauth', 'api', 'php')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- Chart.js Dashboard: javascript, frontend
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'chartjs-dashboard' AND t.slug IN ('javascript', 'frontend')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- Email Queue: php, backend, performance
+INSERT INTO `plugin_plugintag` (`plugin_id`, `plugintag_id`)
+SELECT p.id, t.id FROM `plugin` p, `plugintag` t WHERE p.slug = 'email-queue' AND t.slug IN ('php', 'backend', 'performance')
+ON DUPLICATE KEY UPDATE `plugin_id` = VALUES(`plugin_id`);
+
+-- Update plugin counts in categories
+UPDATE `plugincategory` pc SET `plugin_count` = (
+    SELECT COUNT(*) FROM `plugin` p WHERE p.category_id = pc.id AND p.is_active = 1
+);
+
+-- Update plugin counts in tags
+UPDATE `plugintag` pt SET `plugin_count` = (
+    SELECT COUNT(*) FROM `plugin_plugintag` pp WHERE pp.plugintag_id = pt.id
+);
+
+-- Add authcontrol entries for plugin registry
+INSERT INTO `authcontrol` (`control`, `method`, `level`, `description`) VALUES
+('plugins', 'index', 101, 'Plugin registry - browse all plugins'),
+('plugins', 'category', 101, 'Plugin registry - browse by category'),
+('plugins', 'view', 101, 'Plugin registry - view plugin details'),
+('plugins', 'search', 101, 'Plugin registry - search plugins')
+ON DUPLICATE KEY UPDATE `level` = VALUES(`level`);
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/views/plugins/category.php
+++ b/views/plugins/category.php
@@ -1,0 +1,355 @@
+<div class="container-fluid">
+    <div class="row">
+        <!-- Sidebar - Categories and Tags -->
+        <div class="col-lg-3 col-md-4 mb-4">
+            <!-- Back to All Plugins -->
+            <a href="/plugins" class="btn btn-outline-secondary w-100 mb-3">
+                <i class="bi bi-arrow-left me-2"></i>All Plugins
+            </a>
+
+            <!-- Categories Card -->
+            <div class="card mb-3">
+                <div class="card-header bg-primary text-white">
+                    <i class="bi bi-grid-3x3-gap me-2"></i>Categories
+                </div>
+                <div class="list-group list-group-flush">
+                    <?php foreach ($categories as $cat): ?>
+                    <a href="/plugins/category/<?= htmlspecialchars($cat->slug) ?>"
+                       class="list-group-item list-group-item-action d-flex justify-content-between align-items-center <?= ($category->slug === $cat->slug) ? 'active' : '' ?>">
+                        <span>
+                            <i class="<?= htmlspecialchars($cat->icon ?? 'bi-puzzle') ?> me-2"></i>
+                            <?= htmlspecialchars($cat->name) ?>
+                        </span>
+                        <span class="badge bg-secondary rounded-pill"><?= htmlspecialchars($cat->plugin_count) ?></span>
+                    </a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+
+            <!-- Subcategories if available -->
+            <?php if (!empty($subcategories)): ?>
+            <div class="card mb-3">
+                <div class="card-header bg-info text-white">
+                    <i class="bi bi-diagram-3 me-2"></i>Subcategories
+                </div>
+                <div class="list-group list-group-flush">
+                    <?php foreach ($subcategories as $subcat): ?>
+                    <a href="/plugins/category/<?= htmlspecialchars($subcat->slug) ?>"
+                       class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                        <span>
+                            <i class="<?= htmlspecialchars($subcat->icon ?? 'bi-puzzle') ?> me-2"></i>
+                            <?= htmlspecialchars($subcat->name) ?>
+                        </span>
+                        <span class="badge bg-secondary rounded-pill"><?= htmlspecialchars($subcat->plugin_count) ?></span>
+                    </a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+            <?php endif; ?>
+
+            <!-- Tags Filter Card -->
+            <div class="card">
+                <div class="card-header bg-secondary text-white d-flex justify-content-between align-items-center">
+                    <span><i class="bi bi-tags me-2"></i>Filter by Tags</span>
+                    <?php if (!empty($selectedTags)): ?>
+                    <a href="<?= htmlspecialchars(self::buildCategoryFilterUrl($category->slug, ['tags' => null])) ?>" class="btn btn-sm btn-light">Clear</a>
+                    <?php endif; ?>
+                </div>
+                <div class="card-body" style="max-height: 300px; overflow-y: auto;">
+                    <?php if (empty($tags)): ?>
+                    <p class="text-muted mb-0">No tags available in this category</p>
+                    <?php else: ?>
+                    <div class="d-flex flex-wrap gap-2">
+                        <?php foreach ($tags as $tag): ?>
+                        <?php
+                            $isSelected = in_array($tag['slug'], $selectedTags);
+                            $newTags = $isSelected
+                                ? array_diff($selectedTags, [$tag['slug']])
+                                : array_merge($selectedTags, [$tag['slug']]);
+                            $tagUrl = self::buildCategoryFilterUrl($category->slug, ['tags' => empty($newTags) ? null : implode(',', $newTags), 'page' => null]);
+                        ?>
+                        <a href="<?= htmlspecialchars($tagUrl) ?>"
+                           class="btn btn-sm <?= $isSelected ? 'btn-primary' : 'btn-outline-secondary' ?>">
+                            <?= htmlspecialchars($tag['name']) ?>
+                            <span class="badge <?= $isSelected ? 'bg-light text-primary' : 'bg-secondary' ?>"><?= htmlspecialchars($tag['count']) ?></span>
+                        </a>
+                        <?php endforeach; ?>
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+
+        <!-- Main Content - Plugin Grid -->
+        <div class="col-lg-9 col-md-8">
+            <!-- Category Header -->
+            <div class="card bg-light mb-4">
+                <div class="card-body">
+                    <div class="d-flex align-items-center">
+                        <div class="me-4">
+                            <i class="<?= htmlspecialchars($category->icon ?? 'bi-puzzle') ?> display-4 text-primary"></i>
+                        </div>
+                        <div class="flex-grow-1">
+                            <h1 class="h3 mb-1"><?= htmlspecialchars($category->name) ?></h1>
+                            <?php if (!empty($category->description)): ?>
+                            <p class="text-muted mb-0"><?= htmlspecialchars($category->description) ?></p>
+                            <?php endif; ?>
+                        </div>
+                        <div class="text-end">
+                            <span class="display-6 text-primary"><?= number_format($totalPlugins) ?></span>
+                            <br>
+                            <small class="text-muted">plugin<?= $totalPlugins !== 1 ? 's' : '' ?></small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Search and Sort Row -->
+            <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+                <div>
+                    <?php if (!empty($search)): ?>
+                    <small class="text-muted">
+                        Search results for "<?= htmlspecialchars($search) ?>" in <?= htmlspecialchars($category->name) ?>
+                    </small>
+                    <?php endif; ?>
+                </div>
+                <div class="d-flex gap-2">
+                    <!-- Search Form -->
+                    <form method="GET" action="/plugins/category/<?= htmlspecialchars($category->slug) ?>" class="d-flex">
+                        <?php if (!empty($selectedTags)): ?>
+                        <input type="hidden" name="tags" value="<?= htmlspecialchars(implode(',', $selectedTags)) ?>">
+                        <?php endif; ?>
+                        <div class="input-group">
+                            <input type="text" name="search" class="form-control" placeholder="Search in <?= htmlspecialchars($category->name) ?>..."
+                                   value="<?= htmlspecialchars($search ?? '') ?>">
+                            <button class="btn btn-outline-primary" type="submit">
+                                <i class="bi bi-search"></i>
+                            </button>
+                        </div>
+                    </form>
+
+                    <!-- Sort Dropdown -->
+                    <div class="dropdown">
+                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                            <i class="bi bi-sort-down me-1"></i>
+                            <?php
+                            $sortLabels = [
+                                'downloads' => 'Most Popular',
+                                'rating' => 'Highest Rated',
+                                'name' => 'Name (A-Z)',
+                                'created_at' => 'Newest'
+                            ];
+                            echo $sortLabels[$sort] ?? 'Sort';
+                            ?>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <?php foreach ($sortLabels as $sortKey => $sortLabel): ?>
+                            <li>
+                                <a class="dropdown-item <?= $sort === $sortKey ? 'active' : '' ?>"
+                                   href="<?= htmlspecialchars(self::buildCategoryFilterUrl($category->slug, ['sort' => $sortKey, 'page' => null])) ?>">
+                                    <?= htmlspecialchars($sortLabel) ?>
+                                </a>
+                            </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Active Filters Display -->
+            <?php if (!empty($selectedTags) || !empty($search)): ?>
+            <div class="mb-3">
+                <span class="text-muted me-2">Active filters:</span>
+                <?php foreach ($selectedTags as $tagSlug): ?>
+                <?php
+                    $newTags = array_diff($selectedTags, [$tagSlug]);
+                    $removeUrl = self::buildCategoryFilterUrl($category->slug, ['tags' => empty($newTags) ? null : implode(',', $newTags)]);
+                ?>
+                <a href="<?= htmlspecialchars($removeUrl) ?>" class="badge bg-secondary text-decoration-none me-1">
+                    <?= htmlspecialchars($tagSlug) ?> <i class="bi bi-x"></i>
+                </a>
+                <?php endforeach; ?>
+                <?php if (!empty($search)): ?>
+                <a href="<?= htmlspecialchars(self::buildCategoryFilterUrl($category->slug, ['search' => null])) ?>" class="badge bg-info text-decoration-none me-1">
+                    "<?= htmlspecialchars($search) ?>" <i class="bi bi-x"></i>
+                </a>
+                <?php endif; ?>
+                <a href="/plugins/category/<?= htmlspecialchars($category->slug) ?>" class="text-muted small ms-2">Clear filters</a>
+            </div>
+            <?php endif; ?>
+
+            <!-- Plugin Grid -->
+            <?php if (empty($plugins)): ?>
+            <div class="alert alert-info">
+                <i class="bi bi-info-circle me-2"></i>
+                No plugins found in this category matching your criteria. Try adjusting your filters or
+                <a href="/plugins/category/<?= htmlspecialchars($category->slug) ?>" class="alert-link">view all plugins in <?= htmlspecialchars($category->name) ?></a>.
+            </div>
+            <?php else: ?>
+            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4">
+                <?php foreach ($plugins as $plugin): ?>
+                <div class="col">
+                    <div class="card h-100 plugin-card">
+                        <div class="card-body">
+                            <div class="d-flex align-items-start mb-3">
+                                <div class="plugin-icon me-3">
+                                    <i class="<?= htmlspecialchars($plugin['icon'] ?? 'bi-puzzle-fill') ?> fs-1 text-primary"></i>
+                                </div>
+                                <div class="flex-grow-1">
+                                    <h5 class="card-title mb-1">
+                                        <a href="/plugins/view/<?= htmlspecialchars($plugin['slug']) ?>" class="text-decoration-none text-dark stretched-link">
+                                            <?= htmlspecialchars($plugin['name']) ?>
+                                        </a>
+                                    </h5>
+                                    <small class="text-muted">
+                                        v<?= htmlspecialchars($plugin['version'] ?? '1.0.0') ?>
+                                        by <?= htmlspecialchars($plugin['author'] ?? 'Unknown') ?>
+                                    </small>
+                                </div>
+                            </div>
+                            <p class="card-text text-muted small">
+                                <?= htmlspecialchars($plugin['short_description'] ?? '') ?>
+                            </p>
+                        </div>
+                        <div class="card-footer bg-transparent">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <?php if ($plugin['is_featured']): ?>
+                                <span class="badge bg-warning text-dark">
+                                    <i class="bi bi-star-fill me-1"></i>Featured
+                                </span>
+                                <?php else: ?>
+                                <span></span>
+                                <?php endif; ?>
+                                <span class="text-muted small">
+                                    <i class="bi bi-download me-1"></i><?= number_format($plugin['downloads'] ?? 0) ?>
+                                </span>
+                            </div>
+                            <?php if (!empty($plugin['tags'])): ?>
+                            <div class="d-flex flex-wrap gap-1">
+                                <?php foreach (array_slice($plugin['tags'], 0, 3) as $tag): ?>
+                                <span class="badge bg-light text-secondary"><?= htmlspecialchars($tag['name']) ?></span>
+                                <?php endforeach; ?>
+                                <?php if (count($plugin['tags']) > 3): ?>
+                                <span class="badge bg-light text-secondary">+<?= count($plugin['tags']) - 3 ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+                <?php endforeach; ?>
+            </div>
+
+            <!-- Pagination -->
+            <?php if ($totalPages > 1): ?>
+            <nav aria-label="Plugin pagination" class="mt-4">
+                <ul class="pagination justify-content-center">
+                    <li class="page-item <?= $page <= 1 ? 'disabled' : '' ?>">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildCategoryFilterUrl($category->slug, ['page' => $page - 1])) ?>">
+                            <i class="bi bi-chevron-left"></i> Previous
+                        </a>
+                    </li>
+
+                    <?php
+                    $startPage = max(1, $page - 2);
+                    $endPage = min($totalPages, $page + 2);
+                    ?>
+
+                    <?php if ($startPage > 1): ?>
+                    <li class="page-item">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildCategoryFilterUrl($category->slug, ['page' => 1])) ?>">1</a>
+                    </li>
+                    <?php if ($startPage > 2): ?>
+                    <li class="page-item disabled"><span class="page-link">...</span></li>
+                    <?php endif; ?>
+                    <?php endif; ?>
+
+                    <?php for ($i = $startPage; $i <= $endPage; $i++): ?>
+                    <li class="page-item <?= $i === $page ? 'active' : '' ?>">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildCategoryFilterUrl($category->slug, ['page' => $i])) ?>"><?= $i ?></a>
+                    </li>
+                    <?php endfor; ?>
+
+                    <?php if ($endPage < $totalPages): ?>
+                    <?php if ($endPage < $totalPages - 1): ?>
+                    <li class="page-item disabled"><span class="page-link">...</span></li>
+                    <?php endif; ?>
+                    <li class="page-item">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildCategoryFilterUrl($category->slug, ['page' => $totalPages])) ?>"><?= $totalPages ?></a>
+                    </li>
+                    <?php endif; ?>
+
+                    <li class="page-item <?= $page >= $totalPages ? 'disabled' : '' ?>">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildCategoryFilterUrl($category->slug, ['page' => $page + 1])) ?>">
+                            Next <i class="bi bi-chevron-right"></i>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+            <?php endif; ?>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+
+<style>
+.plugin-card {
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+.plugin-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+.plugin-icon {
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+</style>
+
+<?php
+/**
+ * Helper function to build filter URLs for category page
+ */
+function self_buildCategoryFilterUrl($categorySlug, $changes) {
+    global $selectedTags, $search, $sort, $page;
+
+    $params = [];
+
+    // Tags
+    $tags = array_key_exists('tags', $changes) ? $changes['tags'] : (!empty($selectedTags) ? implode(',', $selectedTags) : null);
+    if ($tags) {
+        $params['tags'] = $tags;
+    }
+
+    // Search
+    $searchParam = array_key_exists('search', $changes) ? $changes['search'] : $search;
+    if ($searchParam) {
+        $params['search'] = $searchParam;
+    }
+
+    // Sort
+    $sortParam = array_key_exists('sort', $changes) ? $changes['sort'] : $sort;
+    if ($sortParam && $sortParam !== 'downloads') {
+        $params['sort'] = $sortParam;
+    }
+
+    // Page
+    $pageParam = array_key_exists('page', $changes) ? $changes['page'] : $page;
+    if ($pageParam && $pageParam > 1) {
+        $params['page'] = $pageParam;
+    }
+
+    $queryString = http_build_query($params);
+    return '/plugins/category/' . $categorySlug . ($queryString ? '?' . $queryString : '');
+}
+
+// Make the function available in the template scope
+class self {
+    public static function buildCategoryFilterUrl($categorySlug, $changes) {
+        return self_buildCategoryFilterUrl($categorySlug, $changes);
+    }
+}
+?>

--- a/views/plugins/index.php
+++ b/views/plugins/index.php
@@ -1,0 +1,358 @@
+<div class="container-fluid">
+    <div class="row">
+        <!-- Sidebar - Categories and Tags -->
+        <div class="col-lg-3 col-md-4 mb-4">
+            <!-- Categories Card -->
+            <div class="card mb-3">
+                <div class="card-header bg-primary text-white">
+                    <i class="bi bi-grid-3x3-gap me-2"></i>Categories
+                </div>
+                <div class="list-group list-group-flush">
+                    <a href="/plugins" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center <?= empty($currentCategory) ? 'active' : '' ?>">
+                        All Plugins
+                        <span class="badge bg-secondary rounded-pill"><?= htmlspecialchars($stats['total_plugins']) ?></span>
+                    </a>
+                    <?php foreach ($categories as $cat): ?>
+                    <a href="/plugins?category=<?= htmlspecialchars($cat->slug) ?>"
+                       class="list-group-item list-group-item-action d-flex justify-content-between align-items-center <?= ($currentCategory && $currentCategory->slug === $cat->slug) ? 'active' : '' ?>">
+                        <span>
+                            <i class="<?= htmlspecialchars($cat->icon ?? 'bi-puzzle') ?> me-2"></i>
+                            <?= htmlspecialchars($cat->name) ?>
+                        </span>
+                        <span class="badge bg-secondary rounded-pill"><?= htmlspecialchars($cat->plugin_count) ?></span>
+                    </a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+
+            <!-- Tags Filter Card -->
+            <div class="card mb-3">
+                <div class="card-header bg-secondary text-white d-flex justify-content-between align-items-center">
+                    <span><i class="bi bi-tags me-2"></i>Filter by Tags</span>
+                    <?php if (!empty($selectedTags)): ?>
+                    <a href="<?= htmlspecialchars(self::buildFilterUrl(['tags' => null])) ?>" class="btn btn-sm btn-light">Clear</a>
+                    <?php endif; ?>
+                </div>
+                <div class="card-body" style="max-height: 300px; overflow-y: auto;">
+                    <?php if (empty($tags)): ?>
+                    <p class="text-muted mb-0">No tags available</p>
+                    <?php else: ?>
+                    <div class="d-flex flex-wrap gap-2">
+                        <?php foreach ($tags as $tag): ?>
+                        <?php
+                            $isSelected = in_array($tag['slug'], $selectedTags);
+                            $newTags = $isSelected
+                                ? array_diff($selectedTags, [$tag['slug']])
+                                : array_merge($selectedTags, [$tag['slug']]);
+                            $tagUrl = self::buildFilterUrl(['tags' => empty($newTags) ? null : implode(',', $newTags), 'page' => null]);
+                        ?>
+                        <a href="<?= htmlspecialchars($tagUrl) ?>"
+                           class="btn btn-sm <?= $isSelected ? 'btn-primary' : 'btn-outline-secondary' ?>">
+                            <?= htmlspecialchars($tag['name']) ?>
+                            <span class="badge <?= $isSelected ? 'bg-light text-primary' : 'bg-secondary' ?>"><?= htmlspecialchars($tag['count']) ?></span>
+                        </a>
+                        <?php endforeach; ?>
+                    </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <!-- Featured Plugins (only on main page without filters) -->
+            <?php if (!empty($featuredPlugins)): ?>
+            <div class="card">
+                <div class="card-header bg-warning text-dark">
+                    <i class="bi bi-star-fill me-2"></i>Featured Plugins
+                </div>
+                <div class="list-group list-group-flush">
+                    <?php foreach ($featuredPlugins as $fp): ?>
+                    <a href="/plugins/view/<?= htmlspecialchars($fp['slug']) ?>" class="list-group-item list-group-item-action">
+                        <div class="d-flex align-items-center">
+                            <i class="<?= htmlspecialchars($fp['icon'] ?? 'bi-puzzle-fill') ?> fs-4 me-3 text-primary"></i>
+                            <div>
+                                <strong><?= htmlspecialchars($fp['name']) ?></strong>
+                                <br>
+                                <small class="text-muted"><?= htmlspecialchars($fp['short_description'] ?? '') ?></small>
+                            </div>
+                        </div>
+                    </a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+            <?php endif; ?>
+        </div>
+
+        <!-- Main Content - Plugin Grid -->
+        <div class="col-lg-9 col-md-8">
+            <!-- Header with search and sort -->
+            <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+                <div>
+                    <h1 class="h3 mb-0">
+                        <?php if ($currentCategory): ?>
+                        <i class="<?= htmlspecialchars($currentCategory->icon ?? 'bi-puzzle') ?> me-2"></i>
+                        <?= htmlspecialchars($currentCategory->name) ?>
+                        <?php else: ?>
+                        <i class="bi bi-box-seam me-2"></i>Plugin Registry
+                        <?php endif; ?>
+                    </h1>
+                    <small class="text-muted">
+                        <?= number_format($totalPlugins) ?> plugin<?= $totalPlugins !== 1 ? 's' : '' ?> found
+                        <?php if (!empty($search)): ?>
+                        for "<?= htmlspecialchars($search) ?>"
+                        <?php endif; ?>
+                    </small>
+                </div>
+                <div class="d-flex gap-2">
+                    <!-- Search Form -->
+                    <form method="GET" action="/plugins" class="d-flex">
+                        <?php if ($currentCategory): ?>
+                        <input type="hidden" name="category" value="<?= htmlspecialchars($currentCategory->slug) ?>">
+                        <?php endif; ?>
+                        <?php if (!empty($selectedTags)): ?>
+                        <input type="hidden" name="tags" value="<?= htmlspecialchars(implode(',', $selectedTags)) ?>">
+                        <?php endif; ?>
+                        <div class="input-group">
+                            <input type="text" name="search" class="form-control" placeholder="Search plugins..."
+                                   value="<?= htmlspecialchars($search ?? '') ?>">
+                            <button class="btn btn-outline-primary" type="submit">
+                                <i class="bi bi-search"></i>
+                            </button>
+                        </div>
+                    </form>
+
+                    <!-- Sort Dropdown -->
+                    <div class="dropdown">
+                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                            <i class="bi bi-sort-down me-1"></i>
+                            <?php
+                            $sortLabels = [
+                                'downloads' => 'Most Popular',
+                                'rating' => 'Highest Rated',
+                                'name' => 'Name (A-Z)',
+                                'created_at' => 'Newest'
+                            ];
+                            echo $sortLabels[$sort] ?? 'Sort';
+                            ?>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <?php foreach ($sortLabels as $sortKey => $sortLabel): ?>
+                            <li>
+                                <a class="dropdown-item <?= $sort === $sortKey ? 'active' : '' ?>"
+                                   href="<?= htmlspecialchars(self::buildFilterUrl(['sort' => $sortKey, 'page' => null])) ?>">
+                                    <?= htmlspecialchars($sortLabel) ?>
+                                </a>
+                            </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Active Filters Display -->
+            <?php if (!empty($selectedTags) || !empty($search) || !empty($currentCategory)): ?>
+            <div class="mb-3">
+                <span class="text-muted me-2">Active filters:</span>
+                <?php if ($currentCategory): ?>
+                <a href="<?= htmlspecialchars(self::buildFilterUrl(['category' => null])) ?>" class="badge bg-primary text-decoration-none me-1">
+                    <?= htmlspecialchars($currentCategory->name) ?> <i class="bi bi-x"></i>
+                </a>
+                <?php endif; ?>
+                <?php foreach ($selectedTags as $tagSlug): ?>
+                <?php
+                    $newTags = array_diff($selectedTags, [$tagSlug]);
+                    $removeUrl = self::buildFilterUrl(['tags' => empty($newTags) ? null : implode(',', $newTags)]);
+                ?>
+                <a href="<?= htmlspecialchars($removeUrl) ?>" class="badge bg-secondary text-decoration-none me-1">
+                    <?= htmlspecialchars($tagSlug) ?> <i class="bi bi-x"></i>
+                </a>
+                <?php endforeach; ?>
+                <?php if (!empty($search)): ?>
+                <a href="<?= htmlspecialchars(self::buildFilterUrl(['search' => null])) ?>" class="badge bg-info text-decoration-none me-1">
+                    "<?= htmlspecialchars($search) ?>" <i class="bi bi-x"></i>
+                </a>
+                <?php endif; ?>
+                <a href="/plugins" class="text-muted small ms-2">Clear all</a>
+            </div>
+            <?php endif; ?>
+
+            <!-- Plugin Grid -->
+            <?php if (empty($plugins)): ?>
+            <div class="alert alert-info">
+                <i class="bi bi-info-circle me-2"></i>
+                No plugins found matching your criteria. Try adjusting your filters or
+                <a href="/plugins" class="alert-link">browse all plugins</a>.
+            </div>
+            <?php else: ?>
+            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4">
+                <?php foreach ($plugins as $plugin): ?>
+                <div class="col">
+                    <div class="card h-100 plugin-card">
+                        <div class="card-body">
+                            <div class="d-flex align-items-start mb-3">
+                                <div class="plugin-icon me-3">
+                                    <i class="<?= htmlspecialchars($plugin['icon'] ?? 'bi-puzzle-fill') ?> fs-1 text-primary"></i>
+                                </div>
+                                <div class="flex-grow-1">
+                                    <h5 class="card-title mb-1">
+                                        <a href="/plugins/view/<?= htmlspecialchars($plugin['slug']) ?>" class="text-decoration-none text-dark stretched-link">
+                                            <?= htmlspecialchars($plugin['name']) ?>
+                                        </a>
+                                    </h5>
+                                    <small class="text-muted">
+                                        v<?= htmlspecialchars($plugin['version'] ?? '1.0.0') ?>
+                                        by <?= htmlspecialchars($plugin['author'] ?? 'Unknown') ?>
+                                    </small>
+                                </div>
+                            </div>
+                            <p class="card-text text-muted small">
+                                <?= htmlspecialchars($plugin['short_description'] ?? '') ?>
+                            </p>
+                        </div>
+                        <div class="card-footer bg-transparent">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <?php if (!empty($plugin['category_name'])): ?>
+                                <span class="badge bg-primary">
+                                    <i class="<?= htmlspecialchars($plugin['category_icon'] ?? 'bi-puzzle') ?> me-1"></i>
+                                    <?= htmlspecialchars($plugin['category_name']) ?>
+                                </span>
+                                <?php else: ?>
+                                <span></span>
+                                <?php endif; ?>
+                                <span class="text-muted small">
+                                    <i class="bi bi-download me-1"></i><?= number_format($plugin['downloads'] ?? 0) ?>
+                                </span>
+                            </div>
+                            <?php if (!empty($plugin['tags'])): ?>
+                            <div class="d-flex flex-wrap gap-1">
+                                <?php foreach (array_slice($plugin['tags'], 0, 3) as $tag): ?>
+                                <span class="badge bg-light text-secondary"><?= htmlspecialchars($tag['name']) ?></span>
+                                <?php endforeach; ?>
+                                <?php if (count($plugin['tags']) > 3): ?>
+                                <span class="badge bg-light text-secondary">+<?= count($plugin['tags']) - 3 ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+                <?php endforeach; ?>
+            </div>
+
+            <!-- Pagination -->
+            <?php if ($totalPages > 1): ?>
+            <nav aria-label="Plugin pagination" class="mt-4">
+                <ul class="pagination justify-content-center">
+                    <li class="page-item <?= $page <= 1 ? 'disabled' : '' ?>">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildFilterUrl(['page' => $page - 1])) ?>">
+                            <i class="bi bi-chevron-left"></i> Previous
+                        </a>
+                    </li>
+
+                    <?php
+                    $startPage = max(1, $page - 2);
+                    $endPage = min($totalPages, $page + 2);
+                    ?>
+
+                    <?php if ($startPage > 1): ?>
+                    <li class="page-item">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildFilterUrl(['page' => 1])) ?>">1</a>
+                    </li>
+                    <?php if ($startPage > 2): ?>
+                    <li class="page-item disabled"><span class="page-link">...</span></li>
+                    <?php endif; ?>
+                    <?php endif; ?>
+
+                    <?php for ($i = $startPage; $i <= $endPage; $i++): ?>
+                    <li class="page-item <?= $i === $page ? 'active' : '' ?>">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildFilterUrl(['page' => $i])) ?>"><?= $i ?></a>
+                    </li>
+                    <?php endfor; ?>
+
+                    <?php if ($endPage < $totalPages): ?>
+                    <?php if ($endPage < $totalPages - 1): ?>
+                    <li class="page-item disabled"><span class="page-link">...</span></li>
+                    <?php endif; ?>
+                    <li class="page-item">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildFilterUrl(['page' => $totalPages])) ?>"><?= $totalPages ?></a>
+                    </li>
+                    <?php endif; ?>
+
+                    <li class="page-item <?= $page >= $totalPages ? 'disabled' : '' ?>">
+                        <a class="page-link" href="<?= htmlspecialchars(self::buildFilterUrl(['page' => $page + 1])) ?>">
+                            Next <i class="bi bi-chevron-right"></i>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+            <?php endif; ?>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+
+<style>
+.plugin-card {
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+.plugin-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+.plugin-icon {
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+</style>
+
+<?php
+/**
+ * Helper function to build filter URLs preserving current parameters
+ */
+function self_buildFilterUrl($changes) {
+    global $currentCategory, $selectedTags, $search, $sort, $page;
+
+    $params = [];
+
+    // Category
+    $category = array_key_exists('category', $changes) ? $changes['category'] : ($currentCategory ? $currentCategory->slug : null);
+    if ($category) {
+        $params['category'] = $category;
+    }
+
+    // Tags
+    $tags = array_key_exists('tags', $changes) ? $changes['tags'] : (!empty($selectedTags) ? implode(',', $selectedTags) : null);
+    if ($tags) {
+        $params['tags'] = $tags;
+    }
+
+    // Search
+    $searchParam = array_key_exists('search', $changes) ? $changes['search'] : $search;
+    if ($searchParam) {
+        $params['search'] = $searchParam;
+    }
+
+    // Sort
+    $sortParam = array_key_exists('sort', $changes) ? $changes['sort'] : $sort;
+    if ($sortParam && $sortParam !== 'downloads') {
+        $params['sort'] = $sortParam;
+    }
+
+    // Page
+    $pageParam = array_key_exists('page', $changes) ? $changes['page'] : $page;
+    if ($pageParam && $pageParam > 1) {
+        $params['page'] = $pageParam;
+    }
+
+    $queryString = http_build_query($params);
+    return '/plugins' . ($queryString ? '?' . $queryString : '');
+}
+
+// Make the function available in the template scope
+class self {
+    public static function buildFilterUrl($changes) {
+        return self_buildFilterUrl($changes);
+    }
+}
+?>

--- a/views/plugins/view.php
+++ b/views/plugins/view.php
@@ -1,0 +1,218 @@
+<div class="container">
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb" class="mb-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/plugins">Plugin Registry</a></li>
+            <?php if (!empty($plugin['category_name'])): ?>
+            <li class="breadcrumb-item">
+                <a href="/plugins/category/<?= htmlspecialchars($plugin['category_slug']) ?>">
+                    <?= htmlspecialchars($plugin['category_name']) ?>
+                </a>
+            </li>
+            <?php endif; ?>
+            <li class="breadcrumb-item active" aria-current="page"><?= htmlspecialchars($plugin['name']) ?></li>
+        </ol>
+    </nav>
+
+    <div class="row">
+        <!-- Main Content -->
+        <div class="col-lg-8">
+            <!-- Plugin Header Card -->
+            <div class="card mb-4">
+                <div class="card-body">
+                    <div class="d-flex align-items-start">
+                        <div class="me-4">
+                            <div class="bg-light rounded p-3">
+                                <i class="<?= htmlspecialchars($plugin['icon'] ?? 'bi-puzzle-fill') ?> display-3 text-primary"></i>
+                            </div>
+                        </div>
+                        <div class="flex-grow-1">
+                            <div class="d-flex justify-content-between align-items-start">
+                                <div>
+                                    <h1 class="h2 mb-1"><?= htmlspecialchars($plugin['name']) ?></h1>
+                                    <p class="text-muted mb-2">
+                                        by <strong><?= htmlspecialchars($plugin['author'] ?? 'Unknown') ?></strong>
+                                        <?php if (!empty($plugin['author_url'])): ?>
+                                        <a href="<?= htmlspecialchars($plugin['author_url']) ?>" target="_blank" class="ms-1">
+                                            <i class="bi bi-box-arrow-up-right"></i>
+                                        </a>
+                                        <?php endif; ?>
+                                    </p>
+                                </div>
+                                <?php if ($plugin['is_featured']): ?>
+                                <span class="badge bg-warning text-dark fs-6">
+                                    <i class="bi bi-star-fill me-1"></i>Featured
+                                </span>
+                                <?php endif; ?>
+                            </div>
+
+                            <p class="lead mb-3"><?= htmlspecialchars($plugin['short_description'] ?? '') ?></p>
+
+                            <!-- Category and Tags -->
+                            <div class="mb-3">
+                                <?php if (!empty($plugin['category_name'])): ?>
+                                <a href="/plugins/category/<?= htmlspecialchars($plugin['category_slug']) ?>" class="badge bg-primary text-decoration-none me-2">
+                                    <i class="<?= htmlspecialchars($plugin['category_icon'] ?? 'bi-puzzle') ?> me-1"></i>
+                                    <?= htmlspecialchars($plugin['category_name']) ?>
+                                </a>
+                                <?php endif; ?>
+                                <?php if (!empty($plugin['tags'])): ?>
+                                <?php foreach ($plugin['tags'] as $tag): ?>
+                                <a href="/plugins?tags=<?= htmlspecialchars($tag['slug']) ?>" class="badge bg-secondary text-decoration-none me-1">
+                                    <?= htmlspecialchars($tag['name']) ?>
+                                </a>
+                                <?php endforeach; ?>
+                                <?php endif; ?>
+                            </div>
+
+                            <!-- Action Buttons -->
+                            <div class="d-flex gap-2">
+                                <button class="btn btn-primary btn-lg" disabled>
+                                    <i class="bi bi-download me-2"></i>Install Plugin
+                                </button>
+                                <button class="btn btn-outline-secondary btn-lg" disabled>
+                                    <i class="bi bi-book me-2"></i>Documentation
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Description Card -->
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="bi bi-file-text me-2"></i>Description</h5>
+                </div>
+                <div class="card-body">
+                    <?php if (!empty($plugin['description'])): ?>
+                    <div class="plugin-description">
+                        <?= nl2br(htmlspecialchars($plugin['description'])) ?>
+                    </div>
+                    <?php else: ?>
+                    <p class="text-muted mb-0">No detailed description available.</p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <!-- Related Plugins -->
+            <?php if (!empty($relatedPlugins)): ?>
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="bi bi-collection me-2"></i>Related Plugins</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row row-cols-1 row-cols-md-3 g-3">
+                        <?php foreach ($relatedPlugins as $related): ?>
+                        <div class="col">
+                            <div class="card h-100">
+                                <div class="card-body">
+                                    <div class="d-flex align-items-center mb-2">
+                                        <i class="<?= htmlspecialchars($related['icon'] ?? 'bi-puzzle-fill') ?> fs-4 text-primary me-2"></i>
+                                        <h6 class="card-title mb-0">
+                                            <a href="/plugins/view/<?= htmlspecialchars($related['slug']) ?>" class="text-decoration-none stretched-link">
+                                                <?= htmlspecialchars($related['name']) ?>
+                                            </a>
+                                        </h6>
+                                    </div>
+                                    <p class="card-text small text-muted">
+                                        <?= htmlspecialchars(substr($related['short_description'] ?? '', 0, 80)) ?>...
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+            <?php endif; ?>
+        </div>
+
+        <!-- Sidebar -->
+        <div class="col-lg-4">
+            <!-- Stats Card -->
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="bi bi-info-circle me-2"></i>Plugin Info</h5>
+                </div>
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item d-flex justify-content-between">
+                        <span class="text-muted">Version</span>
+                        <strong><?= htmlspecialchars($plugin['version'] ?? '1.0.0') ?></strong>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between">
+                        <span class="text-muted">Downloads</span>
+                        <strong><?= number_format($plugin['downloads'] ?? 0) ?></strong>
+                    </li>
+                    <?php if (!empty($plugin['rating']) && $plugin['rating'] > 0): ?>
+                    <li class="list-group-item d-flex justify-content-between">
+                        <span class="text-muted">Rating</span>
+                        <strong>
+                            <?php for ($i = 1; $i <= 5; $i++): ?>
+                            <i class="bi <?= $i <= $plugin['rating'] ? 'bi-star-fill text-warning' : 'bi-star text-muted' ?>"></i>
+                            <?php endfor; ?>
+                            <span class="ms-1">(<?= $plugin['rating_count'] ?? 0 ?>)</span>
+                        </strong>
+                    </li>
+                    <?php endif; ?>
+                    <li class="list-group-item d-flex justify-content-between">
+                        <span class="text-muted">Added</span>
+                        <strong><?= date('M j, Y', strtotime($plugin['created_at'])) ?></strong>
+                    </li>
+                    <?php if (!empty($plugin['updated_at'])): ?>
+                    <li class="list-group-item d-flex justify-content-between">
+                        <span class="text-muted">Updated</span>
+                        <strong><?= date('M j, Y', strtotime($plugin['updated_at'])) ?></strong>
+                    </li>
+                    <?php endif; ?>
+                </ul>
+            </div>
+
+            <!-- Author Card -->
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="bi bi-person me-2"></i>Author</h5>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex align-items-center">
+                        <div class="bg-light rounded-circle p-3 me-3">
+                            <i class="bi bi-person-circle fs-4 text-secondary"></i>
+                        </div>
+                        <div>
+                            <h6 class="mb-0"><?= htmlspecialchars($plugin['author'] ?? 'Unknown') ?></h6>
+                            <?php if (!empty($plugin['author_url'])): ?>
+                            <a href="<?= htmlspecialchars($plugin['author_url']) ?>" target="_blank" class="small">
+                                Visit website <i class="bi bi-box-arrow-up-right"></i>
+                            </a>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Tags Card -->
+            <?php if (!empty($plugin['tags'])): ?>
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="bi bi-tags me-2"></i>Tags</h5>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-wrap gap-2">
+                        <?php foreach ($plugin['tags'] as $tag): ?>
+                        <a href="/plugins?tags=<?= htmlspecialchars($tag['slug']) ?>" class="btn btn-sm btn-outline-secondary">
+                            <?= htmlspecialchars($tag['name']) ?>
+                        </a>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+
+<style>
+.plugin-description {
+    white-space: pre-line;
+}
+</style>


### PR DESCRIPTION
## Summary

Implements category-based browsing and tag filtering for the plugin registry, enabling users to discover plugins organized by functionality type.

### Changes

- Added database schema for plugin registry (categories, tags, plugins, relationships)
- Created PluginRegistryService for plugin filtering, search, and statistics
- Created Plugins controller with index, category, view, and search endpoints
- Created responsive Bootstrap 5 views for plugin browsing

### Features

- **Category browsing**: Plugins organized into logical categories (UI, Database, Integration, Authentication, Analytics, Utilities)
- **Tag filtering**: AND logic - selecting multiple tags shows plugins matching ALL selected tags
- **Filter counts**: Each category and tag shows the number of matching plugins
- **Subcategory support**: Hierarchical category structure with parent_id
- **Search**: Full-text search across plugin names and descriptions
- **Sorting**: By downloads, rating, name, or creation date
- **Pagination**: Support for large plugin lists
- **Responsive design**: Bootstrap 5 card grid with mobile-friendly layout

### Routes

- `GET /plugins` - Main plugin registry with filtering
- `GET /plugins/category/{slug}` - Browse by category
- `GET /plugins/view/{slug}` - Plugin details
- `GET /plugins/search` - AJAX search endpoint
- `GET /plugins/filters` - AJAX filter counts endpoint

## Acceptance Criteria

- [x] **Given** plugins have been categorized and tagged **When** I browse the plugin registry **Then** I see plugins organized into logical categories (UI, Database, Integration, etc.)
- [x] **Given** I select a specific category **When** viewing the category page **Then** I see only plugins that belong to that category with subcategory filtering options
- [x] **Given** I apply multiple tag filters **When** browsing plugins **Then** I see plugins that match all selected tags with filter counts displayed

## Test Plan

- [ ] Navigate to /plugins and verify category sidebar displays with counts
- [ ] Click a category and verify only plugins in that category are shown
- [ ] Select multiple tags and verify only plugins with ALL tags appear
- [ ] Verify filter counts update based on current filters
- [ ] Test responsive layout on mobile viewport

Closes #103