### PR TITLE
feat: Add plugin version tracking and update detection system (#104)

### DIFF
--- a/lib/PluginManager.php
+++ b/lib/PluginManager.php
@@ -1,0 +1,503 @@
+<?php
+/**
+ * Plugin Manager
+ * Handles plugin discovery, manifest loading, and plugin lifecycle management.
+ *
+ * Scans the plugins directory for installed plugins, reads their manifests,
+ * and coordinates with PluginVersionService for version tracking.
+ *
+ * @see GitHub Issue #104
+ */
+
+namespace app\lib;
+
+use \Flight as Flight;
+use \RedBeanPHP\R as R;
+use \app\services\PluginVersionService;
+
+class PluginManager {
+
+    /**
+     * Default plugin directory relative to application root
+     */
+    private const DEFAULT_PLUGIN_DIR = 'lib/plugins';
+
+    /**
+     * Plugin manifest filename
+     */
+    private const MANIFEST_FILE = 'plugin.json';
+
+    /**
+     * Base path for the application
+     */
+    private static ?string $basePath = null;
+
+    /**
+     * Cached plugin manifests
+     */
+    private static array $manifestCache = [];
+
+    /**
+     * Set the base path for plugin discovery
+     *
+     * @param string $path Base path
+     */
+    public static function setBasePath(string $path): void {
+        self::$basePath = rtrim($path, '/');
+        self::$manifestCache = [];
+    }
+
+    /**
+     * Get the base path
+     *
+     * @return string Base path
+     */
+    public static function getBasePath(): string {
+        if (self::$basePath === null) {
+            // Try to determine from Flight config or use dirname of lib
+            try {
+                self::$basePath = Flight::get('app.base_path') ?? dirname(__DIR__);
+            } catch (\Exception $e) {
+                self::$basePath = dirname(__DIR__);
+            }
+        }
+
+        return self::$basePath;
+    }
+
+    /**
+     * Get the plugins directory path
+     *
+     * @return string Full path to plugins directory
+     */
+    public static function getPluginDirectory(): string {
+        return self::getBasePath() . '/' . self::DEFAULT_PLUGIN_DIR;
+    }
+
+    /**
+     * Scan the plugin directory for all plugins
+     *
+     * Looks for:
+     * 1. Subdirectories with plugin.json manifest files
+     * 2. Standalone PHP files with plugin metadata in docblock (legacy format)
+     *
+     * @return array Array of discovered plugin paths
+     */
+    public static function scanPluginDirectory(): array {
+        $pluginDir = self::getPluginDirectory();
+        $discoveredPlugins = [];
+
+        if (!is_dir($pluginDir)) {
+            self::log('Plugin directory not found', ['path' => $pluginDir], 'warning');
+            return [];
+        }
+
+        $entries = scandir($pluginDir);
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $entryPath = $pluginDir . '/' . $entry;
+
+            // Check for directory with plugin.json
+            if (is_dir($entryPath)) {
+                $manifestPath = $entryPath . '/' . self::MANIFEST_FILE;
+                if (file_exists($manifestPath)) {
+                    $discoveredPlugins[] = [
+                        'type' => 'directory',
+                        'path' => $entryPath,
+                        'manifest_path' => $manifestPath,
+                        'name' => $entry,
+                    ];
+                }
+            }
+            // Check for standalone PHP file (legacy single-file plugins)
+            elseif (is_file($entryPath) && pathinfo($entry, PATHINFO_EXTENSION) === 'php') {
+                // Check for companion plugin.json
+                $legacyManifest = $pluginDir . '/' . pathinfo($entry, PATHINFO_FILENAME) . '.json';
+                if (file_exists($legacyManifest)) {
+                    $discoveredPlugins[] = [
+                        'type' => 'file',
+                        'path' => $entryPath,
+                        'manifest_path' => $legacyManifest,
+                        'name' => pathinfo($entry, PATHINFO_FILENAME),
+                    ];
+                } else {
+                    // No manifest, treat as legacy plugin
+                    $discoveredPlugins[] = [
+                        'type' => 'legacy',
+                        'path' => $entryPath,
+                        'manifest_path' => null,
+                        'name' => pathinfo($entry, PATHINFO_FILENAME),
+                    ];
+                }
+            }
+        }
+
+        self::log('Plugin directory scanned', [
+            'path' => $pluginDir,
+            'found' => count($discoveredPlugins),
+        ]);
+
+        return $discoveredPlugins;
+    }
+
+    /**
+     * Load and parse a plugin manifest file
+     *
+     * @param string $pluginPath Path to plugin directory or manifest file
+     * @return array|null Manifest data or null if invalid
+     */
+    public static function loadPluginManifest(string $pluginPath): ?array {
+        // Determine manifest path
+        if (is_dir($pluginPath)) {
+            $manifestPath = $pluginPath . '/' . self::MANIFEST_FILE;
+        } elseif (pathinfo($pluginPath, PATHINFO_EXTENSION) === 'json') {
+            $manifestPath = $pluginPath;
+        } elseif (pathinfo($pluginPath, PATHINFO_EXTENSION) === 'php') {
+            // Check for companion .json file
+            $manifestPath = dirname($pluginPath) . '/' . pathinfo($pluginPath, PATHINFO_FILENAME) . '.json';
+        } else {
+            return null;
+        }
+
+        // Check cache
+        if (isset(self::$manifestCache[$manifestPath])) {
+            return self::$manifestCache[$manifestPath];
+        }
+
+        if (!file_exists($manifestPath)) {
+            return null;
+        }
+
+        $content = file_get_contents($manifestPath);
+        $manifest = json_decode($content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            self::log('Invalid plugin manifest JSON', [
+                'path' => $manifestPath,
+                'error' => json_last_error_msg(),
+            ], 'error');
+            return null;
+        }
+
+        // Validate required fields
+        $required = ['name', 'version'];
+        foreach ($required as $field) {
+            if (empty($manifest[$field])) {
+                self::log('Plugin manifest missing required field', [
+                    'path' => $manifestPath,
+                    'field' => $field,
+                ], 'warning');
+                return null;
+            }
+        }
+
+        // Add computed fields
+        $manifest['manifest_path'] = $manifestPath;
+        $manifest['plugin_path'] = is_dir($pluginPath) ? $pluginPath : dirname($pluginPath);
+
+        // Generate slug if not provided
+        if (empty($manifest['slug'])) {
+            $manifest['slug'] = self::generateSlug($manifest['name']);
+        }
+
+        // Cache and return
+        self::$manifestCache[$manifestPath] = $manifest;
+
+        return $manifest;
+    }
+
+    /**
+     * Register all discovered plugins with the version service
+     *
+     * @param bool $skipExisting Skip plugins that are already registered
+     * @return array Results of registration for each plugin
+     */
+    public static function registerAllPlugins(bool $skipExisting = true): array {
+        $discovered = self::scanPluginDirectory();
+        $results = [];
+
+        foreach ($discovered as $pluginInfo) {
+            $slug = self::generateSlug($pluginInfo['name']);
+
+            // Skip if already registered
+            if ($skipExisting) {
+                $existing = PluginVersionService::getPlugin($slug);
+                if ($existing) {
+                    $results[$slug] = [
+                        'status' => 'skipped',
+                        'reason' => 'Already registered',
+                        'current_version' => $existing->installed_version,
+                    ];
+                    continue;
+                }
+            }
+
+            // Load manifest if available
+            $manifest = null;
+            if ($pluginInfo['manifest_path']) {
+                $manifest = self::loadPluginManifest($pluginInfo['manifest_path']);
+            }
+
+            if ($manifest) {
+                // Register with manifest data
+                try {
+                    $plugin = PluginVersionService::registerPlugin(
+                        $manifest['name'],
+                        $manifest['version'],
+                        $manifest['repository'] ?? null,
+                        [
+                            'slug' => $manifest['slug'] ?? null,
+                            'description' => $manifest['description'] ?? null,
+                            'author' => $manifest['author'] ?? null,
+                            'homepage' => $manifest['homepage'] ?? null,
+                            'plugin_path' => $pluginInfo['path'],
+                            'requires_php' => $manifest['requires']['php'] ?? null,
+                        ]
+                    );
+
+                    $results[$plugin->slug] = [
+                        'status' => 'registered',
+                        'version' => $manifest['version'],
+                        'has_manifest' => true,
+                    ];
+                } catch (\Exception $e) {
+                    $results[$slug] = [
+                        'status' => 'error',
+                        'message' => $e->getMessage(),
+                    ];
+                }
+            } elseif ($pluginInfo['type'] === 'legacy') {
+                // Register legacy plugin with metadata from docblock
+                $metadata = self::extractLegacyMetadata($pluginInfo['path']);
+
+                try {
+                    $plugin = PluginVersionService::registerPlugin(
+                        $metadata['name'] ?? $pluginInfo['name'],
+                        $metadata['version'] ?? '0.0.0',
+                        $metadata['repository'] ?? null,
+                        [
+                            'slug' => $slug,
+                            'description' => $metadata['description'] ?? null,
+                            'author' => $metadata['author'] ?? null,
+                            'plugin_path' => $pluginInfo['path'],
+                        ]
+                    );
+
+                    $results[$plugin->slug] = [
+                        'status' => 'registered',
+                        'version' => $plugin->installed_version,
+                        'has_manifest' => false,
+                        'legacy' => true,
+                    ];
+                } catch (\Exception $e) {
+                    $results[$slug] = [
+                        'status' => 'error',
+                        'message' => $e->getMessage(),
+                    ];
+                }
+            }
+        }
+
+        self::log('Plugins registered', [
+            'total' => count($results),
+            'registered' => count(array_filter($results, fn($r) => $r['status'] === 'registered')),
+            'skipped' => count(array_filter($results, fn($r) => $r['status'] === 'skipped')),
+        ]);
+
+        return $results;
+    }
+
+    /**
+     * Check all registered plugins for updates
+     *
+     * @param bool $force Force check even if recently checked
+     * @return array Update check results
+     */
+    public static function checkAllForUpdates(bool $force = false): array {
+        return PluginVersionService::scanForUpdates(null, $force);
+    }
+
+    /**
+     * Check a specific plugin for updates
+     *
+     * @param string $slug Plugin slug
+     * @param bool $force Force check even if recently checked
+     * @return array Update check result
+     */
+    public static function checkForUpdates(string $slug, bool $force = false): array {
+        $results = PluginVersionService::scanForUpdates($slug, $force);
+        return $results[$slug] ?? ['error' => true, 'message' => 'Plugin not found'];
+    }
+
+    /**
+     * Get all plugins with their current status
+     *
+     * @return array Array of plugin info arrays
+     */
+    public static function getAllPlugins(): array {
+        $plugins = PluginVersionService::getInstalledPlugins();
+        $result = [];
+
+        foreach ($plugins as $plugin) {
+            $result[] = $plugin->toArray();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get plugins that need updates
+     *
+     * @return array Array of plugin info arrays with updates
+     */
+    public static function getPluginsNeedingUpdates(): array {
+        $plugins = PluginVersionService::getPluginsWithUpdates();
+        $result = [];
+
+        foreach ($plugins as $plugin) {
+            $result[] = $plugin->toArray();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Create a plugin manifest template for a legacy plugin
+     *
+     * @param string $pluginPath Path to legacy plugin file
+     * @return array Manifest template data
+     */
+    public static function createManifestTemplate(string $pluginPath): array {
+        $metadata = self::extractLegacyMetadata($pluginPath);
+        $name = pathinfo($pluginPath, PATHINFO_FILENAME);
+
+        return [
+            'name' => $metadata['name'] ?? $name,
+            'slug' => self::generateSlug($metadata['name'] ?? $name),
+            'version' => $metadata['version'] ?? '1.0.0',
+            'description' => $metadata['description'] ?? 'Plugin description',
+            'author' => $metadata['author'] ?? 'MyCTOBot',
+            'repository' => $metadata['repository'] ?? '',
+            'homepage' => '',
+            'requires' => [
+                'php' => '>=8.1',
+            ],
+        ];
+    }
+
+    /**
+     * Write a manifest file for a plugin
+     *
+     * @param string $pluginPath Path to plugin (directory or file)
+     * @param array $manifest Manifest data
+     * @return bool True if successfully written
+     */
+    public static function writeManifest(string $pluginPath, array $manifest): bool {
+        if (is_dir($pluginPath)) {
+            $manifestPath = $pluginPath . '/' . self::MANIFEST_FILE;
+        } else {
+            // Create companion .json file for single-file plugins
+            $manifestPath = dirname($pluginPath) . '/' . pathinfo($pluginPath, PATHINFO_FILENAME) . '.json';
+        }
+
+        $json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        if (file_put_contents($manifestPath, $json) === false) {
+            self::log('Failed to write manifest', ['path' => $manifestPath], 'error');
+            return false;
+        }
+
+        // Clear cache
+        unset(self::$manifestCache[$manifestPath]);
+
+        self::log('Manifest written', ['path' => $manifestPath]);
+
+        return true;
+    }
+
+    /**
+     * Extract metadata from a legacy PHP plugin file docblock
+     *
+     * @param string $filePath Path to PHP file
+     * @return array Extracted metadata
+     */
+    private static function extractLegacyMetadata(string $filePath): array {
+        $metadata = [];
+
+        if (!file_exists($filePath)) {
+            return $metadata;
+        }
+
+        $content = file_get_contents($filePath);
+
+        // Extract docblock
+        if (preg_match('/\/\*\*(.+?)\*\//s', $content, $docblock)) {
+            $docContent = $docblock[1];
+
+            // Extract @tags
+            $patterns = [
+                'name' => '/@(?:package|plugin)\s+(.+?)$/m',
+                'version' => '/@version\s+(.+?)$/m',
+                'author' => '/@author\s+(.+?)$/m',
+                'description' => '/^\s*\*\s+(?!@)(.+?)$/m',
+            ];
+
+            foreach ($patterns as $key => $pattern) {
+                if (preg_match($pattern, $docContent, $match)) {
+                    $metadata[$key] = trim($match[1]);
+                }
+            }
+        }
+
+        // Try to extract class name as fallback for name
+        if (empty($metadata['name'])) {
+            if (preg_match('/class\s+(\w+)/m', $content, $match)) {
+                $metadata['name'] = $match[1];
+            }
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Generate a URL-friendly slug from a name
+     *
+     * @param string $name Plugin name
+     * @return string Slug
+     */
+    private static function generateSlug(string $name): string {
+        $slug = strtolower($name);
+        $slug = preg_replace('/[^a-z0-9-]/', '-', $slug);
+        $slug = preg_replace('/-+/', '-', $slug);
+        return trim($slug, '-');
+    }
+
+    /**
+     * Log a message
+     *
+     * @param string $message Log message
+     * @param array $context Additional context
+     * @param string $level Log level
+     */
+    private static function log(string $message, array $context = [], string $level = 'info'): void {
+        try {
+            $logger = Flight::get('log');
+            if ($logger) {
+                $logger->$level('[PluginManager] ' . $message, $context);
+            }
+        } catch (\Exception $e) {
+            // Logger not available, silently ignore
+        }
+    }
+
+    /**
+     * Clear the manifest cache
+     */
+    public static function clearCache(): void {
+        self::$manifestCache = [];
+    }
+}

--- a/lib/SemVer.php
+++ b/lib/SemVer.php
@@ -1,0 +1,533 @@
+<?php
+/**
+ * SemVer - Semantic Versioning Utility Class
+ *
+ * Provides utilities for parsing, comparing, and validating semantic version strings.
+ * Follows the Semantic Versioning 2.0.0 specification (https://semver.org/)
+ *
+ * @see https://semver.org/
+ * @see GitHub Issue #104
+ */
+
+namespace app\lib;
+
+class SemVer {
+
+    /**
+     * Regular expression pattern for semantic versioning
+     * Matches: major.minor.patch[-prerelease][+build]
+     */
+    private const SEMVER_PATTERN = '/^v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<build>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/';
+
+    /**
+     * Simple version pattern for loose matching (allows incomplete versions)
+     */
+    private const LOOSE_PATTERN = '/^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[.-]?(.+))?$/i';
+
+    /**
+     * Parse a semantic version string into components
+     *
+     * @param string $version Version string to parse
+     * @return array|null Parsed version components or null if invalid
+     *                    Keys: major, minor, patch, prerelease, build
+     */
+    public static function parse(string $version): ?array {
+        $version = trim($version);
+
+        // Try strict semver parsing first
+        if (preg_match(self::SEMVER_PATTERN, $version, $matches)) {
+            // Handle empty strings from optional named groups as null
+            $prerelease = isset($matches['prerelease']) && $matches['prerelease'] !== ''
+                ? $matches['prerelease']
+                : null;
+            $build = isset($matches['build']) && $matches['build'] !== ''
+                ? $matches['build']
+                : null;
+
+            return [
+                'major' => (int) $matches['major'],
+                'minor' => (int) $matches['minor'],
+                'patch' => (int) $matches['patch'],
+                'prerelease' => $prerelease,
+                'build' => $build,
+            ];
+        }
+
+        // Try loose parsing for common formats like "1.0" or "v2"
+        if (preg_match(self::LOOSE_PATTERN, $version, $matches)) {
+            $prerelease = null;
+            $build = null;
+
+            // Check if the fourth group contains prerelease or build info
+            if (!empty($matches[4])) {
+                $extra = $matches[4];
+                // Check for build metadata first (starts with +)
+                if (strpos($extra, '+') === 0) {
+                    // Only build metadata, no prerelease
+                    $build = substr($extra, 1);
+                } elseif (strpos($extra, '+') !== false) {
+                    // Both prerelease and build
+                    [$prerelease, $build] = explode('+', $extra, 2);
+                    if (empty($prerelease)) {
+                        $prerelease = null;
+                    }
+                } else {
+                    // Only prerelease
+                    $prerelease = $extra;
+                }
+            }
+
+            return [
+                'major' => (int) $matches[1],
+                'minor' => isset($matches[2]) && $matches[2] !== '' ? (int) $matches[2] : 0,
+                'patch' => isset($matches[3]) && $matches[3] !== '' ? (int) $matches[3] : 0,
+                'prerelease' => $prerelease,
+                'build' => $build,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Compare two version strings
+     *
+     * @param string $v1 First version
+     * @param string $v2 Second version
+     * @return int -1 if v1 < v2, 0 if equal, 1 if v1 > v2
+     */
+    public static function compare(string $v1, string $v2): int {
+        $parsed1 = self::parse($v1);
+        $parsed2 = self::parse($v2);
+
+        // If either version is invalid, treat invalid versions as less than valid
+        if ($parsed1 === null && $parsed2 === null) {
+            return 0;
+        }
+        if ($parsed1 === null) {
+            return -1;
+        }
+        if ($parsed2 === null) {
+            return 1;
+        }
+
+        // Compare major.minor.patch
+        foreach (['major', 'minor', 'patch'] as $part) {
+            if ($parsed1[$part] < $parsed2[$part]) {
+                return -1;
+            }
+            if ($parsed1[$part] > $parsed2[$part]) {
+                return 1;
+            }
+        }
+
+        // Compare pre-release (a version without pre-release is greater)
+        return self::comparePrerelease($parsed1['prerelease'], $parsed2['prerelease']);
+    }
+
+    /**
+     * Compare pre-release identifiers
+     *
+     * @param string|null $pr1 First pre-release
+     * @param string|null $pr2 Second pre-release
+     * @return int Comparison result
+     */
+    private static function comparePrerelease(?string $pr1, ?string $pr2): int {
+        // No pre-release is greater than any pre-release
+        if ($pr1 === null && $pr2 === null) {
+            return 0;
+        }
+        if ($pr1 === null) {
+            return 1;
+        }
+        if ($pr2 === null) {
+            return -1;
+        }
+
+        // Split pre-release into identifiers
+        $ids1 = explode('.', $pr1);
+        $ids2 = explode('.', $pr2);
+
+        $len = min(count($ids1), count($ids2));
+
+        for ($i = 0; $i < $len; $i++) {
+            $id1 = $ids1[$i];
+            $id2 = $ids2[$i];
+
+            // Numeric identifiers are compared as integers
+            $isNum1 = ctype_digit($id1);
+            $isNum2 = ctype_digit($id2);
+
+            if ($isNum1 && $isNum2) {
+                $diff = (int) $id1 - (int) $id2;
+                if ($diff !== 0) {
+                    return $diff > 0 ? 1 : -1;
+                }
+            } elseif ($isNum1) {
+                // Numeric identifiers have lower precedence than alphanumeric
+                return -1;
+            } elseif ($isNum2) {
+                return 1;
+            } else {
+                // Alphanumeric identifiers are compared lexically
+                $cmp = strcmp($id1, $id2);
+                if ($cmp !== 0) {
+                    return $cmp > 0 ? 1 : -1;
+                }
+            }
+        }
+
+        // Longer pre-release wins if all preceding identifiers are equal
+        if (count($ids1) < count($ids2)) {
+            return -1;
+        }
+        if (count($ids1) > count($ids2)) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Determine the type of update between two versions
+     *
+     * @param string $currentVersion Current installed version
+     * @param string $newVersion New available version
+     * @return string|null 'major', 'minor', 'patch', or null if no update or invalid
+     */
+    public static function getUpdateType(string $currentVersion, string $newVersion): ?string {
+        $current = self::parse($currentVersion);
+        $new = self::parse($newVersion);
+
+        if ($current === null || $new === null) {
+            return null;
+        }
+
+        // Not an update if new is not greater
+        if (self::compare($currentVersion, $newVersion) >= 0) {
+            return null;
+        }
+
+        // Determine update type
+        if ($new['major'] > $current['major']) {
+            return 'major';
+        }
+        if ($new['minor'] > $current['minor']) {
+            return 'minor';
+        }
+        if ($new['patch'] > $current['patch']) {
+            return 'patch';
+        }
+
+        // Pre-release to stable is considered a patch update
+        if ($current['prerelease'] !== null && $new['prerelease'] === null) {
+            return 'patch';
+        }
+
+        // Pre-release update
+        if ($current['prerelease'] !== null && $new['prerelease'] !== null) {
+            return 'patch';
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate if a string is a valid semantic version
+     *
+     * @param string $version Version string to validate
+     * @param bool $strict If true, requires strict semver format (x.y.z)
+     * @return bool True if valid
+     */
+    public static function isValid(string $version, bool $strict = false): bool {
+        $version = trim($version);
+
+        if ($strict) {
+            return preg_match(self::SEMVER_PATTERN, $version) === 1;
+        }
+
+        return self::parse($version) !== null;
+    }
+
+    /**
+     * Check if a version satisfies a constraint
+     *
+     * Supports constraints:
+     * - Exact: "1.0.0"
+     * - Greater than: ">1.0.0"
+     * - Greater than or equal: ">=1.0.0"
+     * - Less than: "<2.0.0"
+     * - Less than or equal: "<=2.0.0"
+     * - Caret (compatible with): "^1.2.3" (>=1.2.3 <2.0.0)
+     * - Tilde (approximately): "~1.2.3" (>=1.2.3 <1.3.0)
+     * - Range: ">=1.0.0 <2.0.0"
+     * - Wildcard: "1.x", "1.2.x", "1.*"
+     *
+     * @param string $version Version to check
+     * @param string $constraint Version constraint
+     * @return bool True if version satisfies the constraint
+     */
+    public static function satisfies(string $version, string $constraint): bool {
+        $version = trim($version);
+        $constraint = trim($constraint);
+
+        // Handle compound constraints (space separated means AND)
+        if (strpos($constraint, ' ') !== false) {
+            $parts = preg_split('/\s+/', $constraint);
+            foreach ($parts as $part) {
+                if (!self::satisfies($version, $part)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Handle pipe (OR) constraints
+        if (strpos($constraint, '||') !== false) {
+            $parts = explode('||', $constraint);
+            foreach ($parts as $part) {
+                if (self::satisfies($version, trim($part))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Handle wildcard constraints (1.x, 1.*, 1.2.x, 1.2.*)
+        if (preg_match('/^(\d+)(?:\.(\d+|x|\*))?(?:\.(\d+|x|\*))?$/', $constraint, $matches)) {
+            $parsed = self::parse($version);
+            if ($parsed === null) {
+                return false;
+            }
+
+            $constraintMajor = (int) $matches[1];
+            $constraintMinor = isset($matches[2]) && $matches[2] !== 'x' && $matches[2] !== '*' ? (int) $matches[2] : null;
+            $constraintPatch = isset($matches[3]) && $matches[3] !== 'x' && $matches[3] !== '*' ? (int) $matches[3] : null;
+
+            if ($parsed['major'] !== $constraintMajor) {
+                return false;
+            }
+            if ($constraintMinor !== null && $parsed['minor'] !== $constraintMinor) {
+                return false;
+            }
+            if ($constraintPatch !== null && $parsed['patch'] !== $constraintPatch) {
+                return false;
+            }
+
+            return true;
+        }
+
+        // Handle caret constraint (^1.2.3)
+        if (strpos($constraint, '^') === 0) {
+            return self::satisfiesCaret($version, substr($constraint, 1));
+        }
+
+        // Handle tilde constraint (~1.2.3)
+        if (strpos($constraint, '~') === 0) {
+            return self::satisfiesTilde($version, substr($constraint, 1));
+        }
+
+        // Handle comparison operators
+        if (preg_match('/^(>=?|<=?|=)?\s*(.+)$/', $constraint, $matches)) {
+            $operator = $matches[1] ?: '=';
+            $constraintVersion = $matches[2];
+
+            $cmp = self::compare($version, $constraintVersion);
+
+            switch ($operator) {
+                case '=':
+                case '==':
+                    return $cmp === 0;
+                case '>':
+                    return $cmp > 0;
+                case '>=':
+                    return $cmp >= 0;
+                case '<':
+                    return $cmp < 0;
+                case '<=':
+                    return $cmp <= 0;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if version satisfies caret constraint
+     * ^1.2.3 means >=1.2.3 <2.0.0
+     * ^0.2.3 means >=0.2.3 <0.3.0
+     * ^0.0.3 means >=0.0.3 <0.0.4
+     */
+    private static function satisfiesCaret(string $version, string $constraint): bool {
+        $parsed = self::parse($constraint);
+        if ($parsed === null) {
+            return false;
+        }
+
+        // Version must be >= constraint
+        if (self::compare($version, $constraint) < 0) {
+            return false;
+        }
+
+        // Determine upper bound
+        if ($parsed['major'] > 0) {
+            $upper = ($parsed['major'] + 1) . '.0.0';
+        } elseif ($parsed['minor'] > 0) {
+            $upper = '0.' . ($parsed['minor'] + 1) . '.0';
+        } else {
+            $upper = '0.0.' . ($parsed['patch'] + 1);
+        }
+
+        return self::compare($version, $upper) < 0;
+    }
+
+    /**
+     * Check if version satisfies tilde constraint
+     * ~1.2.3 means >=1.2.3 <1.3.0
+     */
+    private static function satisfiesTilde(string $version, string $constraint): bool {
+        $parsed = self::parse($constraint);
+        if ($parsed === null) {
+            return false;
+        }
+
+        // Version must be >= constraint
+        if (self::compare($version, $constraint) < 0) {
+            return false;
+        }
+
+        // Upper bound is next minor version
+        $upper = $parsed['major'] . '.' . ($parsed['minor'] + 1) . '.0';
+
+        return self::compare($version, $upper) < 0;
+    }
+
+    /**
+     * Get the normalized version string (without leading 'v')
+     *
+     * @param string $version Version string
+     * @return string|null Normalized version or null if invalid
+     */
+    public static function normalize(string $version): ?string {
+        $parsed = self::parse($version);
+        if ($parsed === null) {
+            return null;
+        }
+
+        $normalized = sprintf('%d.%d.%d', $parsed['major'], $parsed['minor'], $parsed['patch']);
+
+        if ($parsed['prerelease'] !== null) {
+            $normalized .= '-' . $parsed['prerelease'];
+        }
+
+        if ($parsed['build'] !== null) {
+            $normalized .= '+' . $parsed['build'];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Increment a version number by the specified type
+     *
+     * @param string $version Current version
+     * @param string $type Increment type: 'major', 'minor', or 'patch'
+     * @return string|null Incremented version or null if invalid
+     */
+    public static function increment(string $version, string $type = 'patch'): ?string {
+        $parsed = self::parse($version);
+        if ($parsed === null) {
+            return null;
+        }
+
+        switch ($type) {
+            case 'major':
+                $parsed['major']++;
+                $parsed['minor'] = 0;
+                $parsed['patch'] = 0;
+                break;
+            case 'minor':
+                $parsed['minor']++;
+                $parsed['patch'] = 0;
+                break;
+            case 'patch':
+                $parsed['patch']++;
+                break;
+            default:
+                return null;
+        }
+
+        // Clear prerelease and build on increment
+        $parsed['prerelease'] = null;
+        $parsed['build'] = null;
+
+        return self::normalize(
+            sprintf('%d.%d.%d', $parsed['major'], $parsed['minor'], $parsed['patch'])
+        );
+    }
+
+    /**
+     * Check if a version is a pre-release version
+     *
+     * @param string $version Version to check
+     * @return bool True if version has a pre-release identifier
+     */
+    public static function isPrerelease(string $version): bool {
+        $parsed = self::parse($version);
+        return $parsed !== null && $parsed['prerelease'] !== null;
+    }
+
+    /**
+     * Sort an array of version strings in ascending order
+     *
+     * @param array $versions Array of version strings
+     * @return array Sorted array of versions
+     */
+    public static function sort(array $versions): array {
+        usort($versions, [self::class, 'compare']);
+        return $versions;
+    }
+
+    /**
+     * Sort an array of version strings in descending order
+     *
+     * @param array $versions Array of version strings
+     * @return array Sorted array of versions (newest first)
+     */
+    public static function rsort(array $versions): array {
+        usort($versions, function ($a, $b) {
+            return self::compare($b, $a);
+        });
+        return $versions;
+    }
+
+    /**
+     * Find the maximum version in an array
+     *
+     * @param array $versions Array of version strings
+     * @return string|null Maximum version or null if empty
+     */
+    public static function max(array $versions): ?string {
+        if (empty($versions)) {
+            return null;
+        }
+
+        $sorted = self::rsort($versions);
+        return $sorted[0];
+    }
+
+    /**
+     * Find the minimum version in an array
+     *
+     * @param array $versions Array of version strings
+     * @return string|null Minimum version or null if empty
+     */
+    public static function min(array $versions): ?string {
+        if (empty($versions)) {
+            return null;
+        }
+
+        $sorted = self::sort($versions);
+        return $sorted[0];
+    }
+}

--- a/lib/plugins/AtlassianAuth.json
+++ b/lib/plugins/AtlassianAuth.json
@@ -1,0 +1,21 @@
+{
+  "name": "Atlassian OAuth Authentication",
+  "slug": "atlassian-auth",
+  "version": "1.0.0",
+  "description": "Handles Atlassian/Jira authentication for MyCTOBot. Provides OAuth 2.0 integration with Atlassian Cloud for accessing Jira boards and issues.",
+  "author": "MyCTOBot",
+  "repository": "https://github.com/mfrederico/myctobot",
+  "homepage": "https://myctobot.ai",
+  "license": "Proprietary",
+  "requires": {
+    "php": ">=8.1"
+  },
+  "provides": {
+    "auth": ["atlassian", "jira"]
+  },
+  "config": {
+    "atlassian_client_id": "Required: Atlassian OAuth Client ID",
+    "atlassian_client_secret": "Required: Atlassian OAuth Client Secret",
+    "atlassian_redirect_uri": "Required: OAuth callback URL"
+  }
+}

--- a/lib/plugins/GoogleAuth.json
+++ b/lib/plugins/GoogleAuth.json
@@ -1,0 +1,21 @@
+{
+  "name": "Google OAuth Authentication",
+  "slug": "google-auth",
+  "version": "1.0.0",
+  "description": "Handles Google Sign-In authentication for MyCTOBot. Provides OAuth 2.0 integration with Google accounts for user login and registration.",
+  "author": "MyCTOBot",
+  "repository": "https://github.com/mfrederico/myctobot",
+  "homepage": "https://myctobot.ai",
+  "license": "Proprietary",
+  "requires": {
+    "php": ">=8.1"
+  },
+  "provides": {
+    "auth": ["google"]
+  },
+  "config": {
+    "google_client_id": "Required: Google OAuth Client ID",
+    "google_client_secret": "Required: Google OAuth Client Secret",
+    "google_redirect_uri": "Required: OAuth callback URL"
+  }
+}

--- a/models/Model_Pluginregistry.php
+++ b/models/Model_Pluginregistry.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Pluginregistry Model
+ * FUSE model for pluginregistry table
+ *
+ * Tracks installed plugins with version information and update status.
+ *
+ * @see GitHub Issue #104
+ */
+
+use \RedBeanPHP\R as R;
+use \app\lib\SemVer;
+
+class Model_Pluginregistry extends \RedBeanPHP\SimpleModel {
+
+    /**
+     * Valid plugin statuses
+     */
+    private const VALID_STATUSES = ['active', 'inactive', 'disabled'];
+
+    /**
+     * Valid update types
+     */
+    private const VALID_UPDATE_TYPES = ['major', 'minor', 'patch'];
+
+    /**
+     * Called before storing the bean
+     * Auto-sets updated_at timestamp and validates data
+     */
+    public function update() {
+        $this->bean->updated_at = date('Y-m-d H:i:s');
+
+        // Validate status
+        if ($this->bean->status && !in_array($this->bean->status, self::VALID_STATUSES)) {
+            $this->bean->status = 'active';
+        }
+
+        // Validate update_type
+        if ($this->bean->update_type && !in_array($this->bean->update_type, self::VALID_UPDATE_TYPES)) {
+            $this->bean->update_type = null;
+        }
+
+        // Ensure slug is lowercase and valid
+        if ($this->bean->slug) {
+            $this->bean->slug = strtolower(preg_replace('/[^a-zA-Z0-9-]/', '-', $this->bean->slug));
+        }
+
+        // Validate installed_version is valid semver
+        if ($this->bean->installed_version && !SemVer::isValid($this->bean->installed_version)) {
+            // Attempt to normalize, or keep as-is for loose version formats
+            $normalized = SemVer::normalize($this->bean->installed_version);
+            if ($normalized !== null) {
+                $this->bean->installed_version = $normalized;
+            }
+        }
+    }
+
+    /**
+     * Called after dispense (when creating a new bean)
+     * Sets default values
+     */
+    public function dispense() {
+        $this->bean->status = 'active';
+        $this->bean->update_available = false;
+        $this->bean->installed_at = date('Y-m-d H:i:s');
+        $this->bean->created_at = date('Y-m-d H:i:s');
+    }
+
+    /**
+     * Check if the plugin has an available update
+     *
+     * @return bool True if an update is available
+     */
+    public function hasUpdate(): bool {
+        return (bool) $this->bean->update_available;
+    }
+
+    /**
+     * Get the latest available version
+     *
+     * @return string|null Latest version or null if not checked
+     */
+    public function getLatestVersion(): ?string {
+        return $this->bean->latest_version ?: null;
+    }
+
+    /**
+     * Mark that an update is available
+     *
+     * @param string $version The latest available version
+     * @param string $type The update type: 'major', 'minor', or 'patch'
+     * @return void
+     */
+    public function markUpdateAvailable(string $version, string $type): void {
+        if (!in_array($type, self::VALID_UPDATE_TYPES)) {
+            throw new \InvalidArgumentException("Invalid update type: {$type}");
+        }
+
+        $this->bean->latest_version = $version;
+        $this->bean->update_available = true;
+        $this->bean->update_type = $type;
+        $this->bean->last_checked_at = date('Y-m-d H:i:s');
+    }
+
+    /**
+     * Mark that no update is available (plugin is up to date)
+     *
+     * @return void
+     */
+    public function markUpToDate(): void {
+        $this->bean->update_available = false;
+        $this->bean->update_type = null;
+        $this->bean->latest_version = $this->bean->installed_version;
+        $this->bean->last_checked_at = date('Y-m-d H:i:s');
+    }
+
+    /**
+     * Update the installed version after applying an update
+     *
+     * @param string $version The new installed version
+     * @return void
+     */
+    public function updateInstalledVersion(string $version): void {
+        $this->bean->installed_version = $version;
+        $this->bean->update_available = false;
+        $this->bean->update_type = null;
+        $this->bean->latest_version = $version;
+    }
+
+    /**
+     * Check if plugin is active
+     *
+     * @return bool True if plugin status is 'active'
+     */
+    public function isActive(): bool {
+        return $this->bean->status === 'active';
+    }
+
+    /**
+     * Activate the plugin
+     *
+     * @return void
+     */
+    public function activate(): void {
+        $this->bean->status = 'active';
+    }
+
+    /**
+     * Deactivate the plugin (can be reactivated)
+     *
+     * @return void
+     */
+    public function deactivate(): void {
+        $this->bean->status = 'inactive';
+    }
+
+    /**
+     * Disable the plugin (requires manual intervention to re-enable)
+     *
+     * @return void
+     */
+    public function disable(): void {
+        $this->bean->status = 'disabled';
+    }
+
+    /**
+     * Get the plugin's version history (related pluginversion beans)
+     * Uses RedBeanPHP association with ordering
+     *
+     * @param int|null $limit Maximum number of versions to return
+     * @return array Array of pluginversion beans
+     */
+    public function getVersionHistory(?int $limit = null): array {
+        $sql = ' ORDER BY released_at DESC';
+        if ($limit !== null) {
+            $sql .= ' LIMIT ' . (int) $limit;
+        }
+
+        return $this->bean->with($sql)->ownPluginversionList;
+    }
+
+    /**
+     * Get the most recent version record from history
+     *
+     * @return \RedBeanPHP\OODBBean|null Most recent version bean or null
+     */
+    public function getMostRecentVersion(): ?\RedBeanPHP\OODBBean {
+        $versions = $this->getVersionHistory(1);
+        return !empty($versions) ? reset($versions) : null;
+    }
+
+    /**
+     * Check if this is a major update
+     *
+     * @return bool True if update_type is 'major'
+     */
+    public function isMajorUpdate(): bool {
+        return $this->hasUpdate() && $this->bean->update_type === 'major';
+    }
+
+    /**
+     * Check if this is a minor update
+     *
+     * @return bool True if update_type is 'minor'
+     */
+    public function isMinorUpdate(): bool {
+        return $this->hasUpdate() && $this->bean->update_type === 'minor';
+    }
+
+    /**
+     * Check if this is a patch update
+     *
+     * @return bool True if update_type is 'patch'
+     */
+    public function isPatchUpdate(): bool {
+        return $this->hasUpdate() && $this->bean->update_type === 'patch';
+    }
+
+    /**
+     * Get time since last update check
+     *
+     * @return \DateInterval|null Time difference or null if never checked
+     */
+    public function getTimeSinceLastCheck(): ?\DateInterval {
+        if (!$this->bean->last_checked_at) {
+            return null;
+        }
+
+        $lastCheck = new \DateTime($this->bean->last_checked_at);
+        $now = new \DateTime();
+
+        return $now->diff($lastCheck);
+    }
+
+    /**
+     * Check if an update check is needed (older than specified interval)
+     *
+     * @param int $hours Hours since last check before re-check is needed
+     * @return bool True if update check is needed
+     */
+    public function needsUpdateCheck(int $hours = 24): bool {
+        if (!$this->bean->last_checked_at) {
+            return true;
+        }
+
+        $lastCheck = new \DateTime($this->bean->last_checked_at);
+        $threshold = new \DateTime("-{$hours} hours");
+
+        return $lastCheck < $threshold;
+    }
+
+    /**
+     * Export plugin info as an array (for API responses)
+     *
+     * @return array Plugin information
+     */
+    public function toArray(): array {
+        return [
+            'id' => $this->bean->id,
+            'name' => $this->bean->name,
+            'slug' => $this->bean->slug,
+            'description' => $this->bean->description,
+            'author' => $this->bean->author,
+            'installed_version' => $this->bean->installed_version,
+            'latest_version' => $this->bean->latest_version,
+            'update_available' => $this->hasUpdate(),
+            'update_type' => $this->bean->update_type,
+            'status' => $this->bean->status,
+            'repository_url' => $this->bean->repository_url,
+            'homepage_url' => $this->bean->homepage_url,
+            'installed_at' => $this->bean->installed_at,
+            'last_checked_at' => $this->bean->last_checked_at,
+        ];
+    }
+}

--- a/models/Model_Pluginversion.php
+++ b/models/Model_Pluginversion.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Pluginversion Model
+ * FUSE model for pluginversion table
+ *
+ * Stores version history with release notes for each plugin.
+ *
+ * @see GitHub Issue #104
+ */
+
+use \RedBeanPHP\R as R;
+use \app\lib\SemVer;
+
+class Model_Pluginversion extends \RedBeanPHP\SimpleModel {
+
+    /**
+     * Called before storing the bean
+     * Validates data and sets created_at on new beans
+     */
+    public function update() {
+        // Normalize version string if valid
+        if ($this->bean->version) {
+            $normalized = SemVer::normalize($this->bean->version);
+            if ($normalized !== null) {
+                $this->bean->version = $normalized;
+            }
+        }
+
+        // Ensure is_prerelease matches the version string
+        if ($this->bean->version) {
+            $this->bean->is_prerelease = SemVer::isPrerelease($this->bean->version) ? 1 : 0;
+        }
+    }
+
+    /**
+     * Called after dispense (when creating a new bean)
+     * Sets default values
+     */
+    public function dispense() {
+        $this->bean->is_prerelease = false;
+        $this->bean->created_at = date('Y-m-d H:i:s');
+    }
+
+    /**
+     * Get the parent plugin from the registry
+     * Uses RedBeanPHP association
+     *
+     * @return \RedBeanPHP\OODBBean|null Parent pluginregistry bean
+     */
+    public function getPlugin(): ?\RedBeanPHP\OODBBean {
+        return $this->bean->pluginregistry;
+    }
+
+    /**
+     * Check if this is a pre-release version
+     *
+     * @return bool True if this is a pre-release (alpha, beta, rc, etc.)
+     */
+    public function isPrerelease(): bool {
+        return (bool) $this->bean->is_prerelease;
+    }
+
+    /**
+     * Check if this version is newer than another version
+     *
+     * @param string $otherVersion Version to compare against
+     * @return bool True if this version is newer
+     */
+    public function isNewerThan(string $otherVersion): bool {
+        return SemVer::compare($this->bean->version, $otherVersion) > 0;
+    }
+
+    /**
+     * Check if this version is older than another version
+     *
+     * @param string $otherVersion Version to compare against
+     * @return bool True if this version is older
+     */
+    public function isOlderThan(string $otherVersion): bool {
+        return SemVer::compare($this->bean->version, $otherVersion) < 0;
+    }
+
+    /**
+     * Get the parsed version components
+     *
+     * @return array|null Parsed version (major, minor, patch, prerelease, build) or null
+     */
+    public function getParsedVersion(): ?array {
+        return SemVer::parse($this->bean->version);
+    }
+
+    /**
+     * Get formatted release date
+     *
+     * @param string $format PHP date format string
+     * @return string|null Formatted date or null if not set
+     */
+    public function getFormattedReleaseDate(string $format = 'F j, Y'): ?string {
+        if (!$this->bean->released_at) {
+            return null;
+        }
+
+        $date = new \DateTime($this->bean->released_at);
+        return $date->format($format);
+    }
+
+    /**
+     * Get time since release
+     *
+     * @return string Human-readable time difference (e.g., "3 days ago")
+     */
+    public function getTimeSinceRelease(): string {
+        if (!$this->bean->released_at) {
+            return 'unknown';
+        }
+
+        $released = new \DateTime($this->bean->released_at);
+        $now = new \DateTime();
+        $diff = $now->diff($released);
+
+        if ($diff->y > 0) {
+            return $diff->y . ' year' . ($diff->y > 1 ? 's' : '') . ' ago';
+        }
+        if ($diff->m > 0) {
+            return $diff->m . ' month' . ($diff->m > 1 ? 's' : '') . ' ago';
+        }
+        if ($diff->d > 0) {
+            return $diff->d . ' day' . ($diff->d > 1 ? 's' : '') . ' ago';
+        }
+        if ($diff->h > 0) {
+            return $diff->h . ' hour' . ($diff->h > 1 ? 's' : '') . ' ago';
+        }
+        if ($diff->i > 0) {
+            return $diff->i . ' minute' . ($diff->i > 1 ? 's' : '') . ' ago';
+        }
+
+        return 'just now';
+    }
+
+    /**
+     * Get summary of release notes (first paragraph or truncated)
+     *
+     * @param int $maxLength Maximum length of summary
+     * @return string|null Summary or null if no release notes
+     */
+    public function getReleaseNotesSummary(int $maxLength = 200): ?string {
+        if (!$this->bean->release_notes) {
+            return null;
+        }
+
+        $notes = $this->bean->release_notes;
+
+        // Get first paragraph
+        $paragraphs = preg_split('/\n\n+/', $notes, 2);
+        $summary = $paragraphs[0];
+
+        // Truncate if too long
+        if (strlen($summary) > $maxLength) {
+            $summary = substr($summary, 0, $maxLength - 3) . '...';
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Check if this version has release notes
+     *
+     * @return bool True if release notes exist
+     */
+    public function hasReleaseNotes(): bool {
+        return !empty($this->bean->release_notes);
+    }
+
+    /**
+     * Check if this version has a download URL
+     *
+     * @return bool True if download URL exists
+     */
+    public function hasDownloadUrl(): bool {
+        return !empty($this->bean->download_url);
+    }
+
+    /**
+     * Get the update type from the previously installed version to this one
+     *
+     * @param string $fromVersion The version being updated from
+     * @return string|null 'major', 'minor', 'patch', or null
+     */
+    public function getUpdateTypeFrom(string $fromVersion): ?string {
+        return SemVer::getUpdateType($fromVersion, $this->bean->version);
+    }
+
+    /**
+     * Export version info as an array (for API responses)
+     *
+     * @return array Version information
+     */
+    public function toArray(): array {
+        return [
+            'id' => $this->bean->id,
+            'version' => $this->bean->version,
+            'release_notes' => $this->bean->release_notes,
+            'release_notes_summary' => $this->getReleaseNotesSummary(),
+            'download_url' => $this->bean->download_url,
+            'is_prerelease' => $this->isPrerelease(),
+            'released_at' => $this->bean->released_at,
+            'time_since_release' => $this->getTimeSinceRelease(),
+            'created_at' => $this->bean->created_at,
+        ];
+    }
+}

--- a/services/PluginVersionService.php
+++ b/services/PluginVersionService.php
@@ -1,0 +1,537 @@
+<?php
+/**
+ * Plugin Version Service
+ * Manages plugin registration, version tracking, and update detection.
+ *
+ * Uses GitHub Releases API to check for new versions of plugins.
+ *
+ * @see GitHub Issue #104
+ */
+
+namespace app\services;
+
+use \Flight as Flight;
+use \RedBeanPHP\R as R;
+use \app\lib\SemVer;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+class PluginVersionService {
+
+    /**
+     * GitHub API base URL
+     */
+    private const GITHUB_API_BASE = 'https://api.github.com';
+
+    /**
+     * Cache duration for update checks (in seconds)
+     */
+    private const UPDATE_CHECK_CACHE_HOURS = 24;
+
+    /**
+     * Register a new plugin in the registry
+     *
+     * @param string $name Human-readable plugin name
+     * @param string $version Current installed version
+     * @param string|null $repositoryUrl GitHub repository URL for update checks
+     * @param array $metadata Additional plugin metadata (slug, description, author, etc.)
+     * @return \RedBeanPHP\OODBBean The created/updated plugin registry bean
+     */
+    public static function registerPlugin(
+        string $name,
+        string $version,
+        ?string $repositoryUrl = null,
+        array $metadata = []
+    ): \RedBeanPHP\OODBBean {
+        // Generate slug from name if not provided
+        $slug = $metadata['slug'] ?? self::generateSlug($name);
+
+        // Check if plugin already exists
+        $plugin = R::findOne('pluginregistry', 'slug = ?', [$slug]);
+
+        if (!$plugin) {
+            $plugin = R::dispense('pluginregistry');
+            $plugin->installed_at = date('Y-m-d H:i:s');
+        }
+
+        // Set/update fields
+        $plugin->name = $name;
+        $plugin->slug = $slug;
+        $plugin->installed_version = SemVer::normalize($version) ?? $version;
+        $plugin->repository_url = $repositoryUrl;
+        $plugin->description = $metadata['description'] ?? $plugin->description;
+        $plugin->author = $metadata['author'] ?? $plugin->author;
+        $plugin->homepage_url = $metadata['homepage'] ?? $plugin->homepage_url;
+        $plugin->plugin_path = $metadata['plugin_path'] ?? $plugin->plugin_path;
+        $plugin->requires_php = $metadata['requires_php'] ?? $plugin->requires_php;
+        $plugin->status = $metadata['status'] ?? $plugin->status ?? 'active';
+
+        R::store($plugin);
+
+        self::log('Plugin registered', [
+            'name' => $name,
+            'version' => $version,
+            'slug' => $slug,
+        ]);
+
+        return $plugin;
+    }
+
+    /**
+     * Scan for updates for one or all plugins
+     *
+     * @param string|null $pluginSlug Specific plugin slug, or null for all plugins
+     * @param bool $force Force check even if recently checked
+     * @return array Results with plugin slugs as keys
+     */
+    public static function scanForUpdates(?string $pluginSlug = null, bool $force = false): array {
+        $results = [];
+
+        if ($pluginSlug !== null) {
+            $plugins = R::find('pluginregistry', 'slug = ? AND status != ?', [$pluginSlug, 'disabled']);
+        } else {
+            $plugins = R::find('pluginregistry', 'status != ?', ['disabled']);
+        }
+
+        foreach ($plugins as $plugin) {
+            // Skip if recently checked (unless forced)
+            if (!$force && !$plugin->needsUpdateCheck(self::UPDATE_CHECK_CACHE_HOURS)) {
+                $results[$plugin->slug] = [
+                    'skipped' => true,
+                    'reason' => 'Recently checked',
+                    'last_checked' => $plugin->last_checked_at,
+                ];
+                continue;
+            }
+
+            try {
+                $updateInfo = self::checkPluginForUpdates($plugin);
+                $results[$plugin->slug] = $updateInfo;
+            } catch (\Exception $e) {
+                $results[$plugin->slug] = [
+                    'error' => true,
+                    'message' => $e->getMessage(),
+                ];
+                self::log('Update check failed', [
+                    'plugin' => $plugin->slug,
+                    'error' => $e->getMessage(),
+                ], 'error');
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Check a specific plugin for updates
+     *
+     * @param \RedBeanPHP\OODBBean $plugin Plugin registry bean
+     * @return array Update information
+     */
+    private static function checkPluginForUpdates(\RedBeanPHP\OODBBean $plugin): array {
+        if (empty($plugin->repository_url)) {
+            $plugin->last_checked_at = date('Y-m-d H:i:s');
+            R::store($plugin);
+
+            return [
+                'update_available' => false,
+                'reason' => 'No repository URL configured',
+            ];
+        }
+
+        // Parse GitHub repository URL
+        $repoInfo = self::parseGitHubUrl($plugin->repository_url);
+        if (!$repoInfo) {
+            return [
+                'update_available' => false,
+                'reason' => 'Invalid or unsupported repository URL',
+            ];
+        }
+
+        // Fetch releases from GitHub
+        $releases = self::fetchGitHubReleases($repoInfo['owner'], $repoInfo['repo']);
+
+        if (empty($releases)) {
+            $plugin->markUpToDate();
+            R::store($plugin);
+
+            return [
+                'update_available' => false,
+                'reason' => 'No releases found',
+            ];
+        }
+
+        // Find the latest stable release
+        $latestRelease = null;
+        $latestVersion = null;
+
+        foreach ($releases as $release) {
+            // Skip pre-releases unless no stable found
+            if ($release['prerelease'] && $latestRelease !== null) {
+                continue;
+            }
+
+            $version = ltrim($release['tag_name'], 'v');
+
+            if ($latestVersion === null || SemVer::compare($version, $latestVersion) > 0) {
+                $latestVersion = $version;
+                $latestRelease = $release;
+            }
+        }
+
+        if (!$latestVersion) {
+            $plugin->markUpToDate();
+            R::store($plugin);
+
+            return [
+                'update_available' => false,
+                'reason' => 'No valid version found',
+            ];
+        }
+
+        // Record all versions in history
+        foreach ($releases as $release) {
+            $version = ltrim($release['tag_name'], 'v');
+            self::recordVersion(
+                $plugin->slug,
+                $version,
+                $release['body'] ?? null,
+                $release['published_at'] ?? null,
+                $release['tarball_url'] ?? null,
+                $release['prerelease'] ?? false
+            );
+        }
+
+        // Compare with installed version
+        $updateType = SemVer::getUpdateType($plugin->installed_version, $latestVersion);
+
+        if ($updateType !== null) {
+            $plugin->markUpdateAvailable($latestVersion, $updateType);
+            R::store($plugin);
+
+            self::log('Update available', [
+                'plugin' => $plugin->slug,
+                'current' => $plugin->installed_version,
+                'latest' => $latestVersion,
+                'type' => $updateType,
+            ]);
+
+            return [
+                'update_available' => true,
+                'current_version' => $plugin->installed_version,
+                'latest_version' => $latestVersion,
+                'update_type' => $updateType,
+                'release_notes' => $latestRelease['body'] ?? null,
+                'download_url' => $latestRelease['tarball_url'] ?? null,
+            ];
+        }
+
+        $plugin->markUpToDate();
+        R::store($plugin);
+
+        return [
+            'update_available' => false,
+            'current_version' => $plugin->installed_version,
+            'latest_version' => $latestVersion,
+        ];
+    }
+
+    /**
+     * Get all installed plugins
+     *
+     * @param string|null $status Filter by status (null for all)
+     * @return array Array of plugin registry beans
+     */
+    public static function getInstalledPlugins(?string $status = null): array {
+        if ($status !== null) {
+            return R::find('pluginregistry', 'status = ? ORDER BY name ASC', [$status]);
+        }
+
+        return R::find('pluginregistry', ' ORDER BY name ASC');
+    }
+
+    /**
+     * Get plugins that have available updates
+     *
+     * @param string|null $updateType Filter by update type ('major', 'minor', 'patch')
+     * @return array Array of plugin registry beans with updates
+     */
+    public static function getPluginsWithUpdates(?string $updateType = null): array {
+        if ($updateType !== null) {
+            return R::find(
+                'pluginregistry',
+                'update_available = ? AND update_type = ? ORDER BY name ASC',
+                [true, $updateType]
+            );
+        }
+
+        return R::find('pluginregistry', 'update_available = ? ORDER BY name ASC', [true]);
+    }
+
+    /**
+     * Record a version in the version history
+     *
+     * @param string $pluginSlug Plugin slug
+     * @param string $version Version number
+     * @param string|null $releaseNotes Release notes
+     * @param string|null $releasedAt Release date (ISO 8601)
+     * @param string|null $downloadUrl Download URL
+     * @param bool $isPrerelease Is this a pre-release?
+     * @return \RedBeanPHP\OODBBean|null The version bean or null if plugin not found
+     */
+    public static function recordVersion(
+        string $pluginSlug,
+        string $version,
+        ?string $releaseNotes = null,
+        ?string $releasedAt = null,
+        ?string $downloadUrl = null,
+        bool $isPrerelease = false
+    ): ?\RedBeanPHP\OODBBean {
+        $plugin = R::findOne('pluginregistry', 'slug = ?', [$pluginSlug]);
+
+        if (!$plugin) {
+            return null;
+        }
+
+        $normalizedVersion = SemVer::normalize($version) ?? $version;
+
+        // Check if this version already exists
+        $existingVersion = R::findOne(
+            'pluginversion',
+            'pluginregistry_id = ? AND version = ?',
+            [$plugin->id, $normalizedVersion]
+        );
+
+        if ($existingVersion) {
+            // Update existing record if release notes changed
+            if ($releaseNotes !== null && $existingVersion->release_notes !== $releaseNotes) {
+                $existingVersion->release_notes = $releaseNotes;
+                R::store($existingVersion);
+            }
+            return $existingVersion;
+        }
+
+        // Create new version record
+        $versionBean = R::dispense('pluginversion');
+        $versionBean->pluginregistry_id = $plugin->id;
+        $versionBean->version = $normalizedVersion;
+        $versionBean->release_notes = $releaseNotes;
+        $versionBean->download_url = $downloadUrl;
+        $versionBean->is_prerelease = $isPrerelease ? 1 : 0;
+        $versionBean->released_at = $releasedAt ? date('Y-m-d H:i:s', strtotime($releasedAt)) : null;
+
+        R::store($versionBean);
+
+        return $versionBean;
+    }
+
+    /**
+     * Compare two version strings
+     *
+     * @param string $v1 First version
+     * @param string $v2 Second version
+     * @return int -1 if v1 < v2, 0 if equal, 1 if v1 > v2
+     */
+    public static function compareVersions(string $v1, string $v2): int {
+        return SemVer::compare($v1, $v2);
+    }
+
+    /**
+     * Get the type of update between two versions
+     *
+     * @param string $currentVersion Current version
+     * @param string $newVersion New version
+     * @return string|null 'major', 'minor', 'patch', or null
+     */
+    public static function getUpdateType(string $currentVersion, string $newVersion): ?string {
+        return SemVer::getUpdateType($currentVersion, $newVersion);
+    }
+
+    /**
+     * Get plugin by slug
+     *
+     * @param string $slug Plugin slug
+     * @return \RedBeanPHP\OODBBean|null Plugin bean or null
+     */
+    public static function getPlugin(string $slug): ?\RedBeanPHP\OODBBean {
+        return R::findOne('pluginregistry', 'slug = ?', [$slug]);
+    }
+
+    /**
+     * Get version history for a plugin
+     *
+     * @param string $pluginSlug Plugin slug
+     * @param int|null $limit Maximum versions to return
+     * @return array Array of version beans
+     */
+    public static function getVersionHistory(string $pluginSlug, ?int $limit = null): array {
+        $plugin = R::findOne('pluginregistry', 'slug = ?', [$pluginSlug]);
+
+        if (!$plugin) {
+            return [];
+        }
+
+        $sql = 'pluginregistry_id = ? ORDER BY released_at DESC';
+        $params = [$plugin->id];
+
+        if ($limit !== null) {
+            $sql .= ' LIMIT ' . (int) $limit;
+        }
+
+        return R::find('pluginversion', $sql, $params);
+    }
+
+    /**
+     * Unregister a plugin
+     *
+     * @param string $pluginSlug Plugin slug
+     * @return bool True if successfully removed
+     */
+    public static function unregisterPlugin(string $pluginSlug): bool {
+        $plugin = R::findOne('pluginregistry', 'slug = ?', [$pluginSlug]);
+
+        if (!$plugin) {
+            return false;
+        }
+
+        // This will cascade delete version history due to FK constraint
+        R::trash($plugin);
+
+        self::log('Plugin unregistered', ['slug' => $pluginSlug]);
+
+        return true;
+    }
+
+    /**
+     * Get update statistics
+     *
+     * @return array Statistics about plugin updates
+     */
+    public static function getUpdateStats(): array {
+        $total = R::count('pluginregistry', 'status != ?', ['disabled']);
+        $withUpdates = R::count('pluginregistry', 'update_available = ? AND status != ?', [true, 'disabled']);
+        $majorUpdates = R::count('pluginregistry', 'update_type = ? AND status != ?', ['major', 'disabled']);
+        $minorUpdates = R::count('pluginregistry', 'update_type = ? AND status != ?', ['minor', 'disabled']);
+        $patchUpdates = R::count('pluginregistry', 'update_type = ? AND status != ?', ['patch', 'disabled']);
+
+        return [
+            'total_plugins' => $total,
+            'plugins_with_updates' => $withUpdates,
+            'major_updates' => $majorUpdates,
+            'minor_updates' => $minorUpdates,
+            'patch_updates' => $patchUpdates,
+            'up_to_date' => $total - $withUpdates,
+        ];
+    }
+
+    /**
+     * Parse a GitHub repository URL
+     *
+     * @param string $url GitHub URL
+     * @return array|null Array with 'owner' and 'repo' keys, or null if invalid
+     */
+    private static function parseGitHubUrl(string $url): ?array {
+        // Match various GitHub URL formats
+        $patterns = [
+            '/github\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?(?:\/.*)?$/i',
+            '/^([^\/]+)\/([^\/]+)$/', // owner/repo format
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $url, $matches)) {
+                return [
+                    'owner' => $matches[1],
+                    'repo' => rtrim($matches[2], '.git'),
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Fetch releases from GitHub API
+     *
+     * @param string $owner Repository owner
+     * @param string $repo Repository name
+     * @return array Array of release data
+     */
+    private static function fetchGitHubReleases(string $owner, string $repo): array {
+        $url = self::GITHUB_API_BASE . "/repos/{$owner}/{$repo}/releases";
+
+        try {
+            $client = new Client([
+                'timeout' => 10,
+                'headers' => self::getGitHubHeaders(),
+            ]);
+
+            $response = $client->get($url);
+            $data = json_decode($response->getBody()->getContents(), true);
+
+            return is_array($data) ? $data : [];
+        } catch (GuzzleException $e) {
+            self::log('GitHub API request failed', [
+                'url' => $url,
+                'error' => $e->getMessage(),
+            ], 'error');
+
+            return [];
+        }
+    }
+
+    /**
+     * Get GitHub API headers
+     *
+     * @return array Headers for GitHub API requests
+     */
+    private static function getGitHubHeaders(): array {
+        $headers = [
+            'Accept' => 'application/vnd.github+json',
+            'X-GitHub-Api-Version' => '2022-11-28',
+            'User-Agent' => 'MyCTOBot-PluginVersionService',
+        ];
+
+        // Add auth token if available
+        try {
+            $token = Flight::get('github.access_token');
+            if (!empty($token)) {
+                $headers['Authorization'] = 'Bearer ' . $token;
+            }
+        } catch (\Exception $e) {
+            // No token configured, continue without auth
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Generate a URL-friendly slug from a name
+     *
+     * @param string $name Plugin name
+     * @return string Slug
+     */
+    private static function generateSlug(string $name): string {
+        $slug = strtolower($name);
+        $slug = preg_replace('/[^a-z0-9-]/', '-', $slug);
+        $slug = preg_replace('/-+/', '-', $slug);
+        return trim($slug, '-');
+    }
+
+    /**
+     * Log a message
+     *
+     * @param string $message Log message
+     * @param array $context Additional context
+     * @param string $level Log level
+     */
+    private static function log(string $message, array $context = [], string $level = 'info'): void {
+        try {
+            $logger = Flight::get('log');
+            if ($logger) {
+                $logger->$level('[PluginVersionService] ' . $message, $context);
+            }
+        } catch (\Exception $e) {
+            // Logger not available, silently ignore
+        }
+    }
+}

--- a/sql/migrations/add_plugin_tracking.sql
+++ b/sql/migrations/add_plugin_tracking.sql
@@ -1,0 +1,110 @@
+-- Migration: Add plugin version tracking tables
+-- Issue: #104 - Track plugin versions and detect updates
+-- Date: 2026-01-11
+--
+-- This migration creates tables to track:
+-- - pluginregistry: Installed plugins with version info and update status
+-- - pluginversion: Version history with release notes for each plugin
+--
+-- Usage:
+--   MySQL: mysql -u user -p database_name < sql/migrations/add_plugin_tracking.sql
+--   SQLite: sqlite3 database.sqlite < sql/migrations/add_plugin_tracking.sql
+
+-- ============================================================================
+-- Plugin Registry Table
+-- Tracks installed plugins and their update status
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS `pluginregistry` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `name` VARCHAR(255) NOT NULL COMMENT 'Human-readable plugin name',
+    `slug` VARCHAR(100) NOT NULL UNIQUE COMMENT 'Unique identifier (lowercase, hyphenated)',
+    `description` TEXT DEFAULT NULL COMMENT 'Plugin description',
+    `repository_url` VARCHAR(500) DEFAULT NULL COMMENT 'GitHub repository URL for update checks',
+    `homepage_url` VARCHAR(500) DEFAULT NULL COMMENT 'Plugin homepage or documentation URL',
+    `author` VARCHAR(255) DEFAULT NULL COMMENT 'Plugin author name',
+    `installed_version` VARCHAR(50) NOT NULL COMMENT 'Currently installed version (semver)',
+    `latest_version` VARCHAR(50) DEFAULT NULL COMMENT 'Latest available version from repository',
+    `update_available` TINYINT(1) DEFAULT 0 COMMENT 'Flag indicating if update is available',
+    `update_type` ENUM('major', 'minor', 'patch') DEFAULT NULL COMMENT 'Type of available update',
+    `status` ENUM('active', 'inactive', 'disabled') DEFAULT 'active' COMMENT 'Plugin status',
+    `plugin_path` VARCHAR(500) DEFAULT NULL COMMENT 'Relative path to plugin directory',
+    `requires_php` VARCHAR(50) DEFAULT NULL COMMENT 'Minimum PHP version required',
+    `installed_at` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT 'When the plugin was first installed',
+    `last_checked_at` DATETIME DEFAULT NULL COMMENT 'Last time update check was performed',
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT 'Record creation timestamp',
+    `updated_at` DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT 'Record update timestamp'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+COMMENT='Registry of installed plugins with version tracking';
+
+-- Index for efficient queries on update status
+CREATE INDEX IF NOT EXISTS `idx_plugin_update_available` ON `pluginregistry` (`update_available`);
+CREATE INDEX IF NOT EXISTS `idx_plugin_status` ON `pluginregistry` (`status`);
+CREATE INDEX IF NOT EXISTS `idx_plugin_last_checked` ON `pluginregistry` (`last_checked_at`);
+
+-- ============================================================================
+-- Plugin Version Table
+-- Stores version history with release notes for each plugin
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS `pluginversion` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `pluginregistry_id` INT NOT NULL COMMENT 'Reference to plugin in registry',
+    `version` VARCHAR(50) NOT NULL COMMENT 'Version number (semver format)',
+    `release_notes` TEXT DEFAULT NULL COMMENT 'Release notes / changelog for this version',
+    `download_url` VARCHAR(500) DEFAULT NULL COMMENT 'URL to download this version',
+    `is_prerelease` TINYINT(1) DEFAULT 0 COMMENT 'Flag for pre-release versions (alpha, beta, rc)',
+    `released_at` DATETIME DEFAULT NULL COMMENT 'When this version was released',
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT 'Record creation timestamp',
+    FOREIGN KEY (`pluginregistry_id`) REFERENCES `pluginregistry`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+COMMENT='Version history for each plugin with release notes';
+
+-- Index for efficient version queries
+CREATE INDEX IF NOT EXISTS `idx_version_plugin` ON `pluginversion` (`pluginregistry_id`);
+CREATE INDEX IF NOT EXISTS `idx_version_released` ON `pluginversion` (`released_at`);
+CREATE INDEX IF NOT EXISTS `idx_version_prerelease` ON `pluginversion` (`is_prerelease`);
+
+-- Unique constraint: one record per plugin-version combination
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_version_unique` ON `pluginversion` (`pluginregistry_id`, `version`);
+
+-- ============================================================================
+-- SQLite Alternative Syntax (uncomment if using SQLite)
+-- ============================================================================
+--
+-- CREATE TABLE IF NOT EXISTS pluginregistry (
+--     id INTEGER PRIMARY KEY AUTOINCREMENT,
+--     name TEXT NOT NULL,
+--     slug TEXT NOT NULL UNIQUE,
+--     description TEXT,
+--     repository_url TEXT,
+--     homepage_url TEXT,
+--     author TEXT,
+--     installed_version TEXT NOT NULL,
+--     latest_version TEXT,
+--     update_available INTEGER DEFAULT 0,
+--     update_type TEXT CHECK(update_type IN ('major', 'minor', 'patch')),
+--     status TEXT DEFAULT 'active' CHECK(status IN ('active', 'inactive', 'disabled')),
+--     plugin_path TEXT,
+--     requires_php TEXT,
+--     installed_at TEXT DEFAULT CURRENT_TIMESTAMP,
+--     last_checked_at TEXT,
+--     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+--     updated_at TEXT
+-- );
+--
+-- CREATE TABLE IF NOT EXISTS pluginversion (
+--     id INTEGER PRIMARY KEY AUTOINCREMENT,
+--     pluginregistry_id INTEGER NOT NULL,
+--     version TEXT NOT NULL,
+--     release_notes TEXT,
+--     download_url TEXT,
+--     is_prerelease INTEGER DEFAULT 0,
+--     released_at TEXT,
+--     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+--     FOREIGN KEY (pluginregistry_id) REFERENCES pluginregistry(id) ON DELETE CASCADE,
+--     UNIQUE(pluginregistry_id, version)
+-- );
+--
+-- CREATE INDEX IF NOT EXISTS idx_plugin_update_available ON pluginregistry (update_available);
+-- CREATE INDEX IF NOT EXISTS idx_plugin_status ON pluginregistry (status);
+-- CREATE INDEX IF NOT EXISTS idx_version_plugin ON pluginversion (pluginregistry_id);
+-- CREATE INDEX IF NOT EXISTS idx_version_released ON pluginversion (released_at);

--- a/tests/unit/PluginVersionServiceTest.php
+++ b/tests/unit/PluginVersionServiceTest.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * Plugin Version Service Unit Tests
+ *
+ * Tests the PluginVersionService and SemVer utility for version tracking functionality.
+ * Run with: php tests/unit/PluginVersionServiceTest.php
+ *
+ * @see GitHub Issue #104
+ */
+
+namespace app\tests\unit;
+
+// Load required files
+require_once __DIR__ . '/../../lib/SemVer.php';
+
+use app\lib\SemVer;
+
+class PluginVersionServiceTest {
+
+    private static int $passed = 0;
+    private static int $failed = 0;
+    private static array $errors = [];
+
+    /**
+     * Run all tests
+     */
+    public static function run(): void {
+        echo "=== Plugin Version Service Unit Tests ===\n\n";
+
+        // SemVer tests
+        self::testSemVerParsing();
+        self::testSemVerComparison();
+        self::testSemVerUpdateType();
+        self::testSemVerValidation();
+        self::testSemVerConstraints();
+        self::testSemVerPrerelease();
+        self::testSemVerSorting();
+        self::testSemVerNormalization();
+        self::testSemVerIncrement();
+
+        self::printResults();
+    }
+
+    /**
+     * Test semantic version parsing
+     */
+    private static function testSemVerParsing(): void {
+        echo "Testing SemVer parsing...\n";
+
+        // Standard semver
+        $result = SemVer::parse('1.2.3');
+        self::assertEqual($result['major'], 1, 'Parse major');
+        self::assertEqual($result['minor'], 2, 'Parse minor');
+        self::assertEqual($result['patch'], 3, 'Parse patch');
+        self::assertNull($result['prerelease'], 'No prerelease');
+        self::assertNull($result['build'], 'No build');
+
+        // With v prefix
+        $result = SemVer::parse('v2.0.0');
+        self::assertEqual($result['major'], 2, 'Parse with v prefix');
+
+        // With prerelease
+        $result = SemVer::parse('1.0.0-alpha.1');
+        self::assertEqual($result['prerelease'], 'alpha.1', 'Parse prerelease');
+
+        // With build metadata
+        $result = SemVer::parse('1.0.0+build.123');
+        self::assertEqual($result['build'], 'build.123', 'Parse build metadata');
+
+        // With both prerelease and build
+        $result = SemVer::parse('1.0.0-beta.2+build.456');
+        self::assertEqual($result['prerelease'], 'beta.2', 'Parse prerelease with build');
+        self::assertEqual($result['build'], 'build.456', 'Parse build with prerelease');
+
+        // Loose format (incomplete version)
+        $result = SemVer::parse('1.0');
+        self::assertNotNull($result, 'Parse loose version');
+        self::assertEqual($result['patch'], 0, 'Default patch to 0');
+
+        // Invalid version
+        $result = SemVer::parse('not-a-version');
+        self::assertNull($result, 'Invalid version returns null');
+
+        echo "\n";
+    }
+
+    /**
+     * Test version comparison
+     */
+    private static function testSemVerComparison(): void {
+        echo "Testing SemVer comparison...\n";
+
+        // Basic comparisons
+        self::assertEqual(SemVer::compare('1.0.0', '2.0.0'), -1, '1.0.0 < 2.0.0');
+        self::assertEqual(SemVer::compare('2.0.0', '1.0.0'), 1, '2.0.0 > 1.0.0');
+        self::assertEqual(SemVer::compare('1.0.0', '1.0.0'), 0, '1.0.0 == 1.0.0');
+
+        // Minor version comparison
+        self::assertEqual(SemVer::compare('1.1.0', '1.2.0'), -1, '1.1.0 < 1.2.0');
+        self::assertEqual(SemVer::compare('1.2.0', '1.1.0'), 1, '1.2.0 > 1.1.0');
+
+        // Patch version comparison
+        self::assertEqual(SemVer::compare('1.0.1', '1.0.2'), -1, '1.0.1 < 1.0.2');
+        self::assertEqual(SemVer::compare('1.0.2', '1.0.1'), 1, '1.0.2 > 1.0.1');
+
+        // Prerelease comparisons
+        self::assertEqual(SemVer::compare('1.0.0-alpha', '1.0.0'), -1, 'Prerelease < stable');
+        self::assertEqual(SemVer::compare('1.0.0', '1.0.0-alpha'), 1, 'Stable > prerelease');
+        self::assertEqual(SemVer::compare('1.0.0-alpha', '1.0.0-beta'), -1, 'alpha < beta');
+        self::assertEqual(SemVer::compare('1.0.0-alpha.1', '1.0.0-alpha.2'), -1, 'alpha.1 < alpha.2');
+
+        // With v prefix
+        self::assertEqual(SemVer::compare('v1.0.0', '1.0.0'), 0, 'v prefix ignored');
+
+        echo "\n";
+    }
+
+    /**
+     * Test update type detection
+     */
+    private static function testSemVerUpdateType(): void {
+        echo "Testing SemVer update type detection...\n";
+
+        // Major update
+        self::assertEqual(SemVer::getUpdateType('1.0.0', '2.0.0'), 'major', 'Major update 1.0.0 -> 2.0.0');
+        self::assertEqual(SemVer::getUpdateType('1.5.3', '2.0.0'), 'major', 'Major update 1.5.3 -> 2.0.0');
+
+        // Minor update
+        self::assertEqual(SemVer::getUpdateType('1.0.0', '1.1.0'), 'minor', 'Minor update 1.0.0 -> 1.1.0');
+        self::assertEqual(SemVer::getUpdateType('1.2.5', '1.3.0'), 'minor', 'Minor update 1.2.5 -> 1.3.0');
+
+        // Patch update
+        self::assertEqual(SemVer::getUpdateType('1.0.0', '1.0.1'), 'patch', 'Patch update 1.0.0 -> 1.0.1');
+        self::assertEqual(SemVer::getUpdateType('1.2.3', '1.2.4'), 'patch', 'Patch update 1.2.3 -> 1.2.4');
+
+        // Prerelease to stable
+        self::assertEqual(SemVer::getUpdateType('1.0.0-beta', '1.0.0'), 'patch', 'Prerelease to stable');
+
+        // Not an update (same version)
+        self::assertNull(SemVer::getUpdateType('1.0.0', '1.0.0'), 'Same version is not an update');
+
+        // Not an update (downgrade)
+        self::assertNull(SemVer::getUpdateType('2.0.0', '1.0.0'), 'Downgrade is not an update');
+
+        echo "\n";
+    }
+
+    /**
+     * Test version validation
+     */
+    private static function testSemVerValidation(): void {
+        echo "Testing SemVer validation...\n";
+
+        // Valid versions
+        self::assertTrue(SemVer::isValid('1.0.0'), 'Valid: 1.0.0');
+        self::assertTrue(SemVer::isValid('v1.0.0'), 'Valid: v1.0.0');
+        self::assertTrue(SemVer::isValid('0.0.1'), 'Valid: 0.0.1');
+        self::assertTrue(SemVer::isValid('1.0.0-alpha'), 'Valid: 1.0.0-alpha');
+        self::assertTrue(SemVer::isValid('1.0.0+build'), 'Valid: 1.0.0+build');
+        self::assertTrue(SemVer::isValid('1.0'), 'Valid loose: 1.0');
+
+        // Invalid versions
+        self::assertFalse(SemVer::isValid('not-valid'), 'Invalid: not-valid');
+        self::assertFalse(SemVer::isValid(''), 'Invalid: empty string');
+        self::assertFalse(SemVer::isValid('abc'), 'Invalid: abc');
+
+        // Strict validation
+        self::assertTrue(SemVer::isValid('1.0.0', true), 'Strict valid: 1.0.0');
+        self::assertFalse(SemVer::isValid('1.0', true), 'Strict invalid: 1.0');
+
+        echo "\n";
+    }
+
+    /**
+     * Test version constraints
+     */
+    private static function testSemVerConstraints(): void {
+        echo "Testing SemVer constraints...\n";
+
+        // Exact match
+        self::assertTrue(SemVer::satisfies('1.0.0', '1.0.0'), 'Exact match');
+        self::assertFalse(SemVer::satisfies('1.0.1', '1.0.0'), 'Exact no match');
+
+        // Greater than
+        self::assertTrue(SemVer::satisfies('2.0.0', '>1.0.0'), 'Greater than');
+        self::assertFalse(SemVer::satisfies('1.0.0', '>1.0.0'), 'Not greater than');
+
+        // Greater than or equal
+        self::assertTrue(SemVer::satisfies('1.0.0', '>=1.0.0'), 'Greater than or equal (equal)');
+        self::assertTrue(SemVer::satisfies('2.0.0', '>=1.0.0'), 'Greater than or equal (greater)');
+        self::assertFalse(SemVer::satisfies('0.9.0', '>=1.0.0'), 'Not greater than or equal');
+
+        // Less than
+        self::assertTrue(SemVer::satisfies('1.0.0', '<2.0.0'), 'Less than');
+        self::assertFalse(SemVer::satisfies('2.0.0', '<2.0.0'), 'Not less than');
+
+        // Caret constraint
+        self::assertTrue(SemVer::satisfies('1.2.3', '^1.2.0'), 'Caret: 1.2.3 satisfies ^1.2.0');
+        self::assertTrue(SemVer::satisfies('1.9.9', '^1.2.0'), 'Caret: 1.9.9 satisfies ^1.2.0');
+        self::assertFalse(SemVer::satisfies('2.0.0', '^1.2.0'), 'Caret: 2.0.0 not satisfy ^1.2.0');
+        self::assertFalse(SemVer::satisfies('1.1.0', '^1.2.0'), 'Caret: 1.1.0 not satisfy ^1.2.0');
+
+        // Tilde constraint
+        self::assertTrue(SemVer::satisfies('1.2.3', '~1.2.0'), 'Tilde: 1.2.3 satisfies ~1.2.0');
+        self::assertTrue(SemVer::satisfies('1.2.9', '~1.2.0'), 'Tilde: 1.2.9 satisfies ~1.2.0');
+        self::assertFalse(SemVer::satisfies('1.3.0', '~1.2.0'), 'Tilde: 1.3.0 not satisfy ~1.2.0');
+
+        // Wildcard constraint
+        self::assertTrue(SemVer::satisfies('1.0.0', '1.x'), 'Wildcard: 1.0.0 satisfies 1.x');
+        self::assertTrue(SemVer::satisfies('1.5.3', '1.x'), 'Wildcard: 1.5.3 satisfies 1.x');
+        self::assertFalse(SemVer::satisfies('2.0.0', '1.x'), 'Wildcard: 2.0.0 not satisfy 1.x');
+
+        // Compound constraint (AND)
+        self::assertTrue(SemVer::satisfies('1.5.0', '>=1.0.0 <2.0.0'), 'Compound: 1.5.0 satisfies range');
+        self::assertFalse(SemVer::satisfies('2.0.0', '>=1.0.0 <2.0.0'), 'Compound: 2.0.0 not satisfy range');
+
+        echo "\n";
+    }
+
+    /**
+     * Test prerelease detection
+     */
+    private static function testSemVerPrerelease(): void {
+        echo "Testing SemVer prerelease detection...\n";
+
+        self::assertTrue(SemVer::isPrerelease('1.0.0-alpha'), 'alpha is prerelease');
+        self::assertTrue(SemVer::isPrerelease('1.0.0-beta.1'), 'beta.1 is prerelease');
+        self::assertTrue(SemVer::isPrerelease('1.0.0-rc.1'), 'rc.1 is prerelease');
+        self::assertFalse(SemVer::isPrerelease('1.0.0'), 'Stable is not prerelease');
+        self::assertFalse(SemVer::isPrerelease('1.0.0+build'), 'Build metadata only is not prerelease');
+
+        echo "\n";
+    }
+
+    /**
+     * Test version sorting
+     */
+    private static function testSemVerSorting(): void {
+        echo "Testing SemVer sorting...\n";
+
+        $versions = ['2.0.0', '1.0.0', '1.1.0', '1.0.1', '3.0.0'];
+        $sorted = SemVer::sort($versions);
+
+        self::assertEqual($sorted[0], '1.0.0', 'Sort: first is 1.0.0');
+        self::assertEqual($sorted[1], '1.0.1', 'Sort: second is 1.0.1');
+        self::assertEqual($sorted[2], '1.1.0', 'Sort: third is 1.1.0');
+        self::assertEqual($sorted[3], '2.0.0', 'Sort: fourth is 2.0.0');
+        self::assertEqual($sorted[4], '3.0.0', 'Sort: fifth is 3.0.0');
+
+        // Reverse sort
+        $rsorted = SemVer::rsort($versions);
+        self::assertEqual($rsorted[0], '3.0.0', 'Rsort: first is 3.0.0');
+        self::assertEqual($rsorted[4], '1.0.0', 'Rsort: last is 1.0.0');
+
+        // Max and min
+        self::assertEqual(SemVer::max($versions), '3.0.0', 'Max version');
+        self::assertEqual(SemVer::min($versions), '1.0.0', 'Min version');
+
+        // With prereleases
+        $versionsWithPre = ['1.0.0', '1.0.0-alpha', '1.0.0-beta', '1.0.1'];
+        $sortedPre = SemVer::sort($versionsWithPre);
+        self::assertEqual($sortedPre[0], '1.0.0-alpha', 'Sort prerelease: alpha first');
+        self::assertEqual($sortedPre[1], '1.0.0-beta', 'Sort prerelease: beta second');
+        self::assertEqual($sortedPre[2], '1.0.0', 'Sort prerelease: stable third');
+
+        echo "\n";
+    }
+
+    /**
+     * Test version normalization
+     */
+    private static function testSemVerNormalization(): void {
+        echo "Testing SemVer normalization...\n";
+
+        self::assertEqual(SemVer::normalize('v1.0.0'), '1.0.0', 'Normalize removes v prefix');
+        self::assertEqual(SemVer::normalize('1.0'), '1.0.0', 'Normalize adds missing patch');
+        self::assertEqual(SemVer::normalize('1.0.0-alpha'), '1.0.0-alpha', 'Normalize keeps prerelease');
+        self::assertEqual(SemVer::normalize('1.0.0+build'), '1.0.0+build', 'Normalize keeps build');
+        self::assertNull(SemVer::normalize('invalid'), 'Normalize returns null for invalid');
+
+        echo "\n";
+    }
+
+    /**
+     * Test version increment
+     */
+    private static function testSemVerIncrement(): void {
+        echo "Testing SemVer increment...\n";
+
+        self::assertEqual(SemVer::increment('1.0.0', 'major'), '2.0.0', 'Increment major');
+        self::assertEqual(SemVer::increment('1.0.0', 'minor'), '1.1.0', 'Increment minor');
+        self::assertEqual(SemVer::increment('1.0.0', 'patch'), '1.0.1', 'Increment patch');
+
+        // Increment resets lower versions
+        self::assertEqual(SemVer::increment('1.2.3', 'major'), '2.0.0', 'Major resets minor and patch');
+        self::assertEqual(SemVer::increment('1.2.3', 'minor'), '1.3.0', 'Minor resets patch');
+
+        // Increment clears prerelease
+        self::assertEqual(SemVer::increment('1.0.0-alpha', 'patch'), '1.0.1', 'Increment clears prerelease');
+
+        echo "\n";
+    }
+
+    // ========================================
+    // Assertion Helpers
+    // ========================================
+
+    private static function assertEqual($actual, $expected, string $message): void {
+        if ($actual === $expected) {
+            echo "  PASS: {$message}\n";
+            self::$passed++;
+        } else {
+            echo "  FAIL: {$message} (expected: " . var_export($expected, true) . ", got: " . var_export($actual, true) . ")\n";
+            self::$failed++;
+            self::$errors[] = $message;
+        }
+    }
+
+    private static function assertTrue($value, string $message): void {
+        self::assertEqual($value, true, $message);
+    }
+
+    private static function assertFalse($value, string $message): void {
+        self::assertEqual($value, false, $message);
+    }
+
+    private static function assertNull($value, string $message): void {
+        if ($value === null) {
+            echo "  PASS: {$message}\n";
+            self::$passed++;
+        } else {
+            echo "  FAIL: {$message} (expected null, got: " . var_export($value, true) . ")\n";
+            self::$failed++;
+            self::$errors[] = $message;
+        }
+    }
+
+    private static function assertNotNull($value, string $message): void {
+        if ($value !== null) {
+            echo "  PASS: {$message}\n";
+            self::$passed++;
+        } else {
+            echo "  FAIL: {$message} (expected not null)\n";
+            self::$failed++;
+            self::$errors[] = $message;
+        }
+    }
+
+    private static function printResults(): void {
+        echo "\n=== Test Results ===\n";
+        echo "Passed: " . self::$passed . "\n";
+        echo "Failed: " . self::$failed . "\n";
+
+        if (!empty(self::$errors)) {
+            echo "\nFailed tests:\n";
+            foreach (self::$errors as $error) {
+                echo "  - {$error}\n";
+            }
+        }
+
+        echo "\n";
+
+        // Exit with appropriate code
+        exit(self::$failed > 0 ? 1 : 0);
+    }
+}
+
+// Run tests if executed directly
+if (php_sapi_name() === 'cli' && basename(__FILE__) === basename($_SERVER['SCRIPT_NAME'] ?? '')) {
+    PluginVersionServiceTest::run();
+}


### PR DESCRIPTION
## Summary

Implements a comprehensive plugin version tracking system that scans plugin repositories, records version history, and detects available updates using semantic versioning comparison.

Closes #104

## Changes

### New Files (9 files, +2582 lines)

1. **Database Migration** (`sql/migrations/add_plugin_tracking.sql`)
   - Creates `pluginregistry` table for tracking installed plugins
   - Creates `pluginversion` table for version history with release notes
   - Includes indexes for efficient queries and SQLite alternative syntax

2. **SemVer Utility** (`lib/SemVer.php`)
   - Full Semantic Versioning 2.0.0 implementation
   - `parse()` - Parse version strings into components
   - `compare()` - Compare versions (-1, 0, 1)
   - `getUpdateType()` - Returns 'major', 'minor', 'patch', or null
   - `isValid()` - Validate semver format
   - `satisfies()` - Check version against constraints (^, ~, >=, <, wildcards)
   - Additional utilities: `normalize()`, `increment()`, `sort()`, `max()`, `min()`

3. **Plugin Registry Model** (`models/Model_Pluginregistry.php`)
   - FUSE model for RedBeanPHP
   - `hasUpdate()`, `getLatestVersion()`, `markUpdateAvailable()` methods
   - Status management (activate, deactivate, disable)
   - Update type detection (isMajorUpdate, isMinorUpdate, isPatchUpdate)

4. **Plugin Version Model** (`models/Model_Pluginversion.php`)
   - FUSE model for version history
   - Version comparison helpers
   - Release notes summary extraction

5. **Plugin Version Service** (`services/PluginVersionService.php`)
   - `registerPlugin()` - Register plugins with version and metadata
   - `scanForUpdates()` - Check GitHub Releases API for updates
   - `getInstalledPlugins()`, `getPluginsWithUpdates()` - Query methods
   - `recordVersion()` - Record version history with release notes
   - `compareVersions()`, `getUpdateType()` - Version comparison wrappers
   - `getUpdateStats()` - Statistics about plugin updates

6. **Plugin Manager** (`lib/PluginManager.php`)
   - `scanPluginDirectory()` - Discover plugins in lib/plugins/
   - `loadPluginManifest()` - Read and validate plugin.json files
   - `registerAllPlugins()` - Register discovered plugins
   - `checkAllForUpdates()` - Trigger update check for all plugins
   - Legacy plugin support (extracts metadata from PHP docblocks)

7. **Plugin Manifests**
   - `lib/plugins/GoogleAuth.json` - Manifest for GoogleAuth plugin
   - `lib/plugins/AtlassianAuth.json` - Manifest for AtlassianAuth plugin

8. **Unit Tests** (`tests/unit/PluginVersionServiceTest.php`)
   - 94 comprehensive tests covering all SemVer functionality
   - Tests for parsing, comparison, update type detection, validation
   - Tests for version constraints (caret, tilde, wildcards, ranges)

## Acceptance Criteria

- [x] **Given** a plugin repository has multiple releases **When** the system scans for updates **Then** it identifies and records all available versions with release notes
  - Implemented via `PluginVersionService::scanForUpdates()` which fetches from GitHub Releases API and calls `recordVersion()` for each release

- [x] **Given** a new version of an installed plugin is available **When** checking for updates **Then** the system flags the plugin as having an available update
  - Implemented via `Model_Pluginregistry::markUpdateAvailable()` which sets `update_available` flag and `latest_version`

- [x] **Given** version information follows semantic versioning **When** comparing versions **Then** the system correctly identifies major, minor, and patch updates
  - Implemented via `SemVer::getUpdateType()` which correctly identifies 'major', 'minor', or 'patch' updates

## Test Results

```
=== Test Results ===
Passed: 94
Failed: 0
```

## How to Use

```php
// Register a plugin
PluginVersionService::registerPlugin(
    'My Plugin',
    '1.0.0',
    'https://github.com/owner/repo',
    ['description' => 'Plugin description']
);

// Check for updates
$results = PluginVersionService::scanForUpdates();

// Get plugins with available updates
$updates = PluginVersionService::getPluginsWithUpdates();

// Compare versions
$cmp = SemVer::compare('1.0.0', '2.0.0'); // -1
$type = SemVer::getUpdateType('1.0.0', '1.1.0'); // 'minor'
```