### PR TITLE
Add plugin scanner for repository source discovery

### DIFF
--- a/controls/PluginRegistry.php
+++ b/controls/PluginRegistry.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Plugin Registry Controller
+ *
+ * Manages plugin discovery, scanning, and viewing.
+ * Provides endpoints for listing discovered plugins and triggering scans.
+ */
+
+namespace app;
+
+use \Flight as Flight;
+use \app\Bean;
+use \app\services\PluginScannerService;
+use \app\services\UserDatabaseService;
+
+require_once __DIR__ . '/../lib/Bean.php';
+require_once __DIR__ . '/../services/PluginScannerService.php';
+require_once __DIR__ . '/../services/UserDatabaseService.php';
+
+class PluginRegistry extends BaseControls\Control {
+
+    private $userDbConnected = false;
+
+    /**
+     * Initialize user database connection
+     */
+    private function initUserDb(): bool {
+        if (!$this->userDbConnected && $this->member && !empty($this->member->ceobot_db)) {
+            try {
+                UserDatabaseService::connect($this->member->id);
+                $this->userDbConnected = true;
+            } catch (\Exception $e) {
+                $this->logger->error('Failed to initialize user database: ' . $e->getMessage());
+                return false;
+            }
+        }
+        return $this->userDbConnected;
+    }
+
+    /**
+     * GET /plugins - List all discovered plugins
+     */
+    public function index(): void {
+        if (!$this->requireLogin()) return;
+
+        if (!$this->initUserDb()) {
+            $this->flash('error', 'User database not initialized');
+            Flight::redirect('/settings/connections');
+            return;
+        }
+
+        try {
+            $status = $this->getParam('status');
+            $scanner = new PluginScannerService();
+
+            $plugins = $scanner->getDiscoveredPlugins($status);
+
+            // Get status counts for filters
+            $statusCounts = [
+                'discovered' => Bean::count('discoveredplugins', 'status = ?', ['discovered']),
+                'validated' => Bean::count('discoveredplugins', 'status = ?', ['validated']),
+                'invalid' => Bean::count('discoveredplugins', 'status = ?', ['invalid']),
+                'installed' => Bean::count('discoveredplugins', 'status = ?', ['installed'])
+            ];
+
+            // Get repository connections for context
+            $repos = Bean::find('repoconnections', 'enabled = ?', [1]);
+            $repoCount = count($repos);
+
+            // Get recent scans
+            $recentScans = $scanner->getScanHistory(5);
+
+            if (Flight::request()->ajax) {
+                $this->jsonSuccess([
+                    'plugins' => $plugins,
+                    'status_counts' => $statusCounts,
+                    'repo_count' => $repoCount,
+                    'recent_scans' => $recentScans
+                ]);
+            } else {
+                $this->render('plugins/index', [
+                    'title' => 'Plugin Registry',
+                    'plugins' => $plugins,
+                    'statusCounts' => $statusCounts,
+                    'repoCount' => $repoCount,
+                    'recentScans' => $recentScans,
+                    'currentStatus' => $status
+                ]);
+            }
+
+        } catch (\Exception $e) {
+            $this->handleException($e, 'Failed to load plugins');
+        }
+    }
+
+    /**
+     * POST /plugins/scan - Trigger a full scan of all repositories
+     */
+    public function scan(): void {
+        if (!$this->requireLogin()) return;
+        if (!$this->validateCSRF()) return;
+
+        if (!$this->initUserDb()) {
+            $this->jsonError('User database not initialized');
+            return;
+        }
+
+        try {
+            $scanner = new PluginScannerService();
+            $result = $scanner->scanAllSources();
+
+            $this->logger->info('Plugin scan triggered', [
+                'member_id' => $this->member->id,
+                'scan_id' => $result['scan_id'],
+                'repos_scanned' => $result['repos_scanned'],
+                'plugins_found' => $result['plugins_found']
+            ]);
+
+            $this->jsonSuccess([
+                'scan_id' => $result['scan_id'],
+                'repos_scanned' => $result['repos_scanned'],
+                'plugins_found' => $result['plugins_found'],
+                'errors_encountered' => $result['errors_encountered'],
+                'plugins' => $result['plugins']
+            ], "Scan completed: {$result['plugins_found']} plugins found in {$result['repos_scanned']} repositories");
+
+        } catch (\Exception $e) {
+            $this->logger->error('Plugin scan failed', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+
+            $this->jsonError('Scan failed: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * POST /plugins/scan/{id} - Scan a single repository
+     */
+    public function scanRepo($params = []): void {
+        if (!$this->requireLogin()) return;
+        if (!$this->validateCSRF()) return;
+
+        if (!$this->initUserDb()) {
+            $this->jsonError('User database not initialized');
+            return;
+        }
+
+        $repoId = $params['operation']->name ?? $this->getParam('id');
+
+        if (!$repoId || !is_numeric($repoId)) {
+            $this->jsonError('Invalid repository ID');
+            return;
+        }
+
+        try {
+            $scanner = new PluginScannerService();
+            $result = $scanner->scanRepository((int)$repoId);
+
+            $this->logger->info('Single repo scan triggered', [
+                'member_id' => $this->member->id,
+                'repo_id' => $repoId,
+                'scan_id' => $result['scan_id'],
+                'plugins_found' => $result['plugins_found']
+            ]);
+
+            if ($result['plugins_found'] > 0) {
+                $message = "Plugin found: {$result['plugins'][0]['name']}";
+            } else {
+                $message = "No plugin.json found in repository";
+            }
+
+            $this->jsonSuccess([
+                'scan_id' => $result['scan_id'],
+                'repos_scanned' => $result['repos_scanned'],
+                'plugins_found' => $result['plugins_found'],
+                'plugins' => $result['plugins']
+            ], $message);
+
+        } catch (\Exception $e) {
+            $this->logger->error('Single repo scan failed', [
+                'repo_id' => $repoId,
+                'error' => $e->getMessage()
+            ]);
+
+            $this->jsonError('Scan failed: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * GET /plugins/scans - List scan history
+     */
+    public function scans(): void {
+        if (!$this->requireLogin()) return;
+
+        if (!$this->initUserDb()) {
+            if (Flight::request()->ajax) {
+                $this->jsonError('User database not initialized');
+            } else {
+                $this->flash('error', 'User database not initialized');
+                Flight::redirect('/settings/connections');
+            }
+            return;
+        }
+
+        try {
+            $limit = (int)($this->getParam('limit') ?? 20);
+            $limit = min($limit, 100); // Cap at 100
+
+            $scanner = new PluginScannerService();
+            $scans = $scanner->getScanHistory($limit);
+
+            if (Flight::request()->ajax) {
+                $this->jsonSuccess(['scans' => $scans]);
+            } else {
+                $this->render('plugins/scans', [
+                    'title' => 'Plugin Scan History',
+                    'scans' => $scans
+                ]);
+            }
+
+        } catch (\Exception $e) {
+            $this->handleException($e, 'Failed to load scan history');
+        }
+    }
+
+    /**
+     * GET /plugins/{id} - View plugin details
+     */
+    public function view($params = []): void {
+        if (!$this->requireLogin()) return;
+
+        if (!$this->initUserDb()) {
+            $this->flash('error', 'User database not initialized');
+            Flight::redirect('/plugins');
+            return;
+        }
+
+        $pluginId = $params['operation']->name ?? $this->getParam('id');
+
+        if (!$pluginId || !is_numeric($pluginId)) {
+            $this->flash('error', 'Invalid plugin ID');
+            Flight::redirect('/plugins');
+            return;
+        }
+
+        try {
+            $scanner = new PluginScannerService();
+            $plugin = $scanner->getPlugin((int)$pluginId);
+
+            if (!$plugin) {
+                $this->flash('error', 'Plugin not found');
+                Flight::redirect('/plugins');
+                return;
+            }
+
+            // Get the associated repository connection
+            $repo = Bean::load('repoconnections', $plugin['repo_connection_id']);
+
+            if (Flight::request()->ajax) {
+                $this->jsonSuccess([
+                    'plugin' => $plugin,
+                    'repo' => $repo ? $repo->export() : null
+                ]);
+            } else {
+                $this->render('plugins/view', [
+                    'title' => 'Plugin: ' . ($plugin['plugin_name'] ?? 'Unknown'),
+                    'plugin' => $plugin,
+                    'repo' => $repo ? $repo->export() : null
+                ]);
+            }
+
+        } catch (\Exception $e) {
+            $this->handleException($e, 'Failed to load plugin details');
+        }
+    }
+}

--- a/scripts/scan-plugins.php
+++ b/scripts/scan-plugins.php
@@ -1,0 +1,194 @@
+#!/usr/bin/env php
+<?php
+/**
+ * MyCTOBot Plugin Scanner CLI
+ *
+ * Background script to scan configured repository sources for plugins.
+ * Can scan all repositories or a single repository.
+ *
+ * USAGE:
+ * ------
+ * # Scan all enabled repositories:
+ * php scripts/scan-plugins.php --script --secret=KEY --verbose
+ *
+ * # Scan a single repository:
+ * php scripts/scan-plugins.php --script --secret=KEY --repo-id=5 --verbose
+ *
+ * # With tenant support:
+ * php scripts/scan-plugins.php --script --secret=KEY --tenant=gwt --verbose
+ *
+ * OPTIONS:
+ * --------
+ *   --script        REQUIRED for CLI execution
+ *   --secret        REQUIRED - Authentication key (cron.api_key in config.ini)
+ *   --repo-id       Optional - Scan only this repository connection ID
+ *   --tenant        Optional - Tenant slug for multi-tenant setups
+ *   --verbose       Show detailed output
+ *   --help          Show this help message
+ *
+ * EXIT CODES:
+ * -----------
+ *   0 - Success (scan completed)
+ *   1 - Error (invalid arguments, authentication failure, scan failure)
+ */
+
+// Determine paths
+$scriptDir = dirname(__FILE__);
+$baseDir = dirname($scriptDir);
+
+// Change to base directory
+chdir($baseDir);
+
+// Parse command line options
+$options = getopt('', [
+    'repo-id:',
+    'tenant:',
+    'verbose',
+    'help',
+    'script',
+    'secret:'
+]);
+
+if (isset($options['help'])) {
+    echo "MyCTOBot Plugin Scanner\n\n";
+    echo "Usage:\n";
+    echo "  php scripts/scan-plugins.php --script --secret=KEY\n\n";
+    echo "Options:\n";
+    echo "  --script      REQUIRED for CLI execution\n";
+    echo "  --secret      REQUIRED - Authentication key (from config.ini)\n";
+    echo "  --repo-id     Scan only this repository connection ID (optional)\n";
+    echo "  --tenant      Tenant slug for multi-tenant setups (optional)\n";
+    echo "  --verbose     Show detailed output\n";
+    echo "  --help        Show this help message\n\n";
+    echo "Examples:\n";
+    echo "  # Scan all repositories\n";
+    echo "  php scripts/scan-plugins.php --script --secret=mykey --verbose\n\n";
+    echo "  # Scan single repository\n";
+    echo "  php scripts/scan-plugins.php --script --secret=mykey --repo-id=5\n\n";
+    echo "  # With tenant\n";
+    echo "  php scripts/scan-plugins.php --script --secret=mykey --tenant=gwt\n";
+    exit(0);
+}
+
+$verbose = isset($options['verbose']);
+
+if ($verbose) {
+    echo "MyCTOBot Plugin Scanner\n";
+    echo "=======================\n";
+    echo "Time: " . date('Y-m-d H:i:s') . "\n";
+    echo "Base: {$baseDir}\n\n";
+}
+
+// Load vendor autoload first
+require_once $baseDir . '/vendor/autoload.php';
+
+// Load bootstrap class and instantiate it
+require_once $baseDir . '/bootstrap.php';
+
+use \Flight as Flight;
+use \app\services\PluginScannerService;
+
+// Load the service
+require_once $baseDir . '/services/PluginScannerService.php';
+
+try {
+    // Determine config file based on tenant parameter
+    $tenant = $options['tenant'] ?? null;
+    if ($tenant) {
+        $configFile = $baseDir . "/conf/config.{$tenant}.ini";
+        if (!file_exists($configFile)) {
+            echo "Error: Tenant config not found: {$configFile}\n";
+            exit(1);
+        }
+    } else {
+        $configFile = $baseDir . '/conf/config.ini';
+    }
+
+    $bootstrap = new \app\Bootstrap($configFile);
+
+    if ($verbose) {
+        echo "Application initialized" . ($tenant ? " (tenant: {$tenant})" : "") . "\n\n";
+    }
+
+    // Validate CLI secret key for authentication
+    $providedSecret = $options['secret'] ?? null;
+    $expectedSecret = Flight::get('cron.api_key');
+
+    if (empty($providedSecret) || !hash_equals($expectedSecret, $providedSecret)) {
+        echo "Error: Invalid or missing --secret parameter\n";
+        echo "The secret key must match cron.api_key in config.ini\n";
+        exit(1);
+    }
+
+    // Get optional repo ID
+    $repoId = isset($options['repo-id']) ? (int)$options['repo-id'] : null;
+
+    // Create scanner service
+    $scanner = new PluginScannerService($verbose);
+
+    // Run the appropriate scan
+    if ($repoId) {
+        if ($verbose) {
+            echo "Scanning single repository (ID: {$repoId})...\n\n";
+        }
+        $result = $scanner->scanRepository($repoId);
+    } else {
+        if ($verbose) {
+            echo "Scanning all enabled repositories...\n\n";
+        }
+        $result = $scanner->scanAllSources();
+    }
+
+    // Output results
+    if ($verbose) {
+        echo "\n=======================\n";
+        echo "Scan Complete!\n";
+        echo "=======================\n";
+        echo "Scan ID:           {$result['scan_id']}\n";
+        echo "Repos scanned:     {$result['repos_scanned']}\n";
+        echo "Plugins found:     {$result['plugins_found']}\n";
+        echo "Errors:            {$result['errors_encountered']}\n";
+
+        if (!empty($result['plugins'])) {
+            echo "\nDiscovered Plugins:\n";
+            foreach ($result['plugins'] as $plugin) {
+                echo "  - {$plugin['name']} v{$plugin['version']} ({$plugin['repo_owner']}/{$plugin['repo_name']})\n";
+            }
+        }
+
+        if (!empty($result['errors'])) {
+            echo "\nErrors:\n";
+            foreach ($result['errors'] as $error) {
+                echo "  - {$error['repo']}: {$error['error']}\n";
+            }
+        }
+    }
+
+    // Exit with appropriate code
+    if ($result['errors_encountered'] > 0 && $result['plugins_found'] === 0) {
+        // All repos failed
+        exit(1);
+    }
+
+    exit(0);
+
+} catch (Exception $e) {
+    $message = "FATAL ERROR: " . $e->getMessage();
+
+    if ($verbose) {
+        echo "\n{$message}\n";
+        echo "Stack trace:\n" . $e->getTraceAsString() . "\n";
+    }
+
+    // Try to log if possible
+    try {
+        $logger = Flight::get('log');
+        if ($logger) {
+            $logger->error($message, ['trace' => $e->getTraceAsString()]);
+        }
+    } catch (Exception $logError) {
+        // Ignore logging errors
+    }
+
+    exit(1);
+}

--- a/services/PluginScannerService.php
+++ b/services/PluginScannerService.php
@@ -1,0 +1,559 @@
+<?php
+/**
+ * Plugin Scanner Service
+ *
+ * Scans configured repository sources to discover plugins based on markers (plugin.json).
+ * Implements exponential backoff for rate limit handling.
+ */
+
+namespace app\services;
+
+use \Flight as Flight;
+use \app\Bean;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+
+require_once __DIR__ . '/GitHubClient.php';
+require_once __DIR__ . '/../lib/Bean.php';
+
+class PluginScannerService {
+
+    /**
+     * Maximum retry attempts for rate-limited requests
+     */
+    const MAX_RETRIES = 3;
+
+    /**
+     * Initial backoff delay in milliseconds (1 second)
+     */
+    const INITIAL_BACKOFF_MS = 1000;
+
+    /**
+     * Expected plugin.json fields for validation
+     */
+    const REQUIRED_PLUGIN_FIELDS = ['name', 'version'];
+    const OPTIONAL_PLUGIN_FIELDS = ['description', 'author', 'main', 'requires'];
+
+    private $logger;
+    private $verbose;
+
+    public function __construct(bool $verbose = false) {
+        $this->logger = Flight::get('log');
+        $this->verbose = $verbose;
+    }
+
+    /**
+     * Scan all enabled repository sources for plugins
+     *
+     * @return array Scan results with statistics
+     */
+    public function scanAllSources(): array {
+        $scanId = $this->startScan();
+
+        $this->log("Starting full plugin scan (scan_id: {$scanId})");
+
+        $stats = [
+            'scan_id' => $scanId,
+            'repos_scanned' => 0,
+            'plugins_found' => 0,
+            'errors_encountered' => 0,
+            'errors' => [],
+            'plugins' => []
+        ];
+
+        try {
+            // Get all enabled repository connections
+            $repos = Bean::find('repoconnections', 'enabled = ?', [1]);
+
+            if (empty($repos)) {
+                $this->log("No enabled repositories found");
+                $this->completeScan($scanId, $stats);
+                return $stats;
+            }
+
+            foreach ($repos as $repo) {
+                try {
+                    $result = $this->scanSingleRepository($repo, $scanId);
+
+                    $stats['repos_scanned']++;
+
+                    if ($result['plugin_found']) {
+                        $stats['plugins_found']++;
+                        $stats['plugins'][] = $result['plugin_data'];
+                    }
+                } catch (\Exception $e) {
+                    $stats['errors_encountered']++;
+                    $stats['errors'][] = [
+                        'repo' => "{$repo->repo_owner}/{$repo->repo_name}",
+                        'error' => $e->getMessage()
+                    ];
+
+                    $this->logger->warning("Error scanning repository", [
+                        'repo' => "{$repo->repo_owner}/{$repo->repo_name}",
+                        'error' => $e->getMessage()
+                    ]);
+                }
+
+                // Update scan progress
+                $this->updateScan($scanId, [
+                    'repos_scanned' => $stats['repos_scanned'],
+                    'plugins_found' => $stats['plugins_found'],
+                    'errors_encountered' => $stats['errors_encountered']
+                ]);
+            }
+
+            $this->completeScan($scanId, $stats);
+
+            $this->log("Scan completed: {$stats['repos_scanned']} repos, {$stats['plugins_found']} plugins found");
+
+        } catch (\Exception $e) {
+            $this->failScan($scanId, $e->getMessage());
+            throw $e;
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Scan a single repository connection for plugins
+     *
+     * @param int $repoConnectionId Repository connection ID
+     * @return array Scan results for this repository
+     */
+    public function scanRepository(int $repoConnectionId): array {
+        $repo = Bean::load('repoconnections', $repoConnectionId);
+
+        if (!$repo || !$repo->id) {
+            throw new \Exception("Repository connection not found: {$repoConnectionId}");
+        }
+
+        if (!$repo->enabled) {
+            throw new \Exception("Repository connection is disabled: {$repoConnectionId}");
+        }
+
+        $scanId = $this->startScan($repoConnectionId);
+
+        $this->log("Starting single repo scan for {$repo->repo_owner}/{$repo->repo_name} (scan_id: {$scanId})");
+
+        $stats = [
+            'scan_id' => $scanId,
+            'repos_scanned' => 0,
+            'plugins_found' => 0,
+            'errors_encountered' => 0,
+            'errors' => [],
+            'plugins' => []
+        ];
+
+        try {
+            $result = $this->scanSingleRepository($repo, $scanId);
+
+            $stats['repos_scanned'] = 1;
+
+            if ($result['plugin_found']) {
+                $stats['plugins_found'] = 1;
+                $stats['plugins'][] = $result['plugin_data'];
+            }
+
+            $this->completeScan($scanId, $stats);
+
+        } catch (\Exception $e) {
+            $stats['errors_encountered'] = 1;
+            $stats['errors'][] = [
+                'repo' => "{$repo->repo_owner}/{$repo->repo_name}",
+                'error' => $e->getMessage()
+            ];
+
+            $this->failScan($scanId, $e->getMessage());
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Scan a single repository bean for plugin markers
+     *
+     * @param \RedBeanPHP\OODBBean $repo Repository connection bean
+     * @param string $scanId Current scan ID
+     * @return array Result with plugin_found flag and plugin_data
+     */
+    private function scanSingleRepository($repo, string $scanId): array {
+        $owner = $repo->repo_owner;
+        $repoName = $repo->repo_name;
+        $accessToken = $repo->access_token;
+
+        $this->log("Scanning {$owner}/{$repoName}...");
+
+        // Decrypt token if needed
+        if (!empty($accessToken) && strpos($accessToken, 'sk-') !== 0) {
+            try {
+                require_once __DIR__ . '/EncryptionService.php';
+                $accessToken = EncryptionService::decrypt($accessToken);
+            } catch (\Exception $e) {
+                // Token may not be encrypted, use as-is
+            }
+        }
+
+        // Fall back to global GitHub token if repo token is empty
+        if (empty($accessToken)) {
+            $tokenSetting = Bean::findOne('enterprisesettings', 'setting_key = ?', ['github_token']);
+            if ($tokenSetting) {
+                $accessToken = $tokenSetting->setting_value;
+            }
+        }
+
+        if (empty($accessToken)) {
+            throw new \Exception("No access token available for {$owner}/{$repoName}");
+        }
+
+        // Check for plugin.json in repository root
+        $pluginJson = $this->detectPluginMarkers($owner, $repoName, $accessToken);
+
+        if ($pluginJson === null) {
+            $this->log("No plugin.json found in {$owner}/{$repoName}");
+            return ['plugin_found' => false, 'plugin_data' => null];
+        }
+
+        // Parse and validate plugin.json
+        $pluginData = $this->parsePluginJson($pluginJson);
+        $pluginData['repo_owner'] = $owner;
+        $pluginData['repo_name'] = $repoName;
+        $pluginData['repo_connection_id'] = $repo->id;
+
+        // Save or update discovered plugin
+        $pluginId = $this->saveDiscoveredPlugin($pluginData, $repo->id);
+        $pluginData['id'] = $pluginId;
+
+        $this->log("Plugin found in {$owner}/{$repoName}: {$pluginData['name']} v{$pluginData['version']}");
+
+        return ['plugin_found' => true, 'plugin_data' => $pluginData];
+    }
+
+    /**
+     * Check if repository has plugin.json in root
+     *
+     * @param string $owner Repository owner
+     * @param string $repo Repository name
+     * @param string $accessToken GitHub access token
+     * @return string|null Plugin.json content or null if not found
+     */
+    public function detectPluginMarkers(string $owner, string $repo, string $accessToken): ?string {
+        $attempt = 0;
+
+        while ($attempt < self::MAX_RETRIES) {
+            try {
+                $client = new GitHubClient($accessToken);
+                $content = $client->getFileContent($owner, $repo, 'plugin.json');
+                return $content;
+
+            } catch (ClientException $e) {
+                $statusCode = $e->getResponse()->getStatusCode();
+
+                if ($statusCode === 404) {
+                    // No plugin.json - this is not an error, just means no plugin
+                    return null;
+                }
+
+                if ($statusCode === 403 || $statusCode === 429) {
+                    // Rate limited - apply exponential backoff
+                    $attempt++;
+                    if ($attempt < self::MAX_RETRIES) {
+                        $this->handleRateLimit($attempt);
+                        continue;
+                    }
+                }
+
+                throw $e;
+
+            } catch (ServerException $e) {
+                // Server error - retry with backoff
+                $attempt++;
+                if ($attempt < self::MAX_RETRIES) {
+                    $this->handleRateLimit($attempt);
+                    continue;
+                }
+                throw $e;
+
+            } catch (\Exception $e) {
+                // Check if it's a 404 wrapped in GuzzleException
+                if (strpos($e->getMessage(), '404') !== false) {
+                    return null;
+                }
+                throw $e;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse and validate plugin.json content
+     *
+     * @param string $content Raw plugin.json content
+     * @return array Parsed plugin data
+     * @throws \Exception If JSON is invalid or missing required fields
+     */
+    public function parsePluginJson(string $content): array {
+        $data = json_decode($content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception("Invalid JSON in plugin.json: " . json_last_error_msg());
+        }
+
+        // Validate required fields
+        foreach (self::REQUIRED_PLUGIN_FIELDS as $field) {
+            if (empty($data[$field])) {
+                throw new \Exception("Missing required field in plugin.json: {$field}");
+            }
+        }
+
+        // Build normalized plugin data
+        return [
+            'name' => $data['name'],
+            'version' => $data['version'],
+            'description' => $data['description'] ?? null,
+            'author' => $data['author'] ?? null,
+            'main' => $data['main'] ?? null,
+            'requires' => $data['requires'] ?? null,
+            'raw_json' => $data,
+            'valid' => true
+        ];
+    }
+
+    /**
+     * Save or update a discovered plugin in the database
+     *
+     * @param array $pluginData Parsed plugin data
+     * @param int $repoConnectionId Repository connection ID
+     * @return int Plugin record ID
+     */
+    public function saveDiscoveredPlugin(array $pluginData, int $repoConnectionId): int {
+        // Generate unique plugin ID based on repo
+        $pluginId = md5("{$pluginData['repo_owner']}/{$pluginData['repo_name']}");
+
+        // Check if plugin already exists
+        $existing = Bean::findOne('discoveredplugins', 'plugin_id = ?', [$pluginId]);
+
+        if ($existing) {
+            // Update existing record
+            $plugin = $existing;
+        } else {
+            // Create new record
+            $plugin = Bean::dispense('discoveredplugins');
+            $plugin->plugin_id = $pluginId;
+            $plugin->discovered_at = date('Y-m-d H:i:s');
+        }
+
+        $plugin->repo_connection_id = $repoConnectionId;
+        $plugin->repo_owner = $pluginData['repo_owner'];
+        $plugin->repo_name = $pluginData['repo_name'];
+        $plugin->plugin_name = $pluginData['name'];
+        $plugin->plugin_description = $pluginData['description'];
+        $plugin->plugin_version = $pluginData['version'];
+        $plugin->plugin_author = $pluginData['author'];
+        $plugin->plugin_main = $pluginData['main'];
+        $plugin->plugin_requires = json_encode($pluginData['requires']);
+        $plugin->plugin_json = json_encode($pluginData['raw_json']);
+        $plugin->status = $pluginData['valid'] ? 'validated' : 'invalid';
+        $plugin->last_scanned_at = date('Y-m-d H:i:s');
+
+        Bean::store($plugin);
+
+        return $plugin->id;
+    }
+
+    /**
+     * Create a new scan record
+     *
+     * @param int|null $repoConnectionId Single repo ID or null for full scan
+     * @return string Generated scan ID
+     */
+    public function startScan(?int $repoConnectionId = null): string {
+        $scanId = bin2hex(random_bytes(16));
+
+        $scan = Bean::dispense('pluginscans');
+        $scan->scan_id = $scanId;
+        $scan->repo_connection_id = $repoConnectionId;
+        $scan->status = 'running';
+        $scan->started_at = date('Y-m-d H:i:s');
+        $scan->repos_scanned = 0;
+        $scan->plugins_found = 0;
+        $scan->errors_encountered = 0;
+
+        Bean::store($scan);
+
+        $this->logger->info("Plugin scan started", [
+            'scan_id' => $scanId,
+            'repo_connection_id' => $repoConnectionId
+        ]);
+
+        return $scanId;
+    }
+
+    /**
+     * Update an in-progress scan record
+     *
+     * @param string $scanId Scan ID
+     * @param array $data Data to update
+     */
+    public function updateScan(string $scanId, array $data): void {
+        $scan = Bean::findOne('pluginscans', 'scan_id = ?', [$scanId]);
+
+        if (!$scan) {
+            return;
+        }
+
+        foreach ($data as $key => $value) {
+            $scan->$key = $value;
+        }
+
+        Bean::store($scan);
+    }
+
+    /**
+     * Mark a scan as completed
+     *
+     * @param string $scanId Scan ID
+     * @param array $stats Final statistics
+     */
+    public function completeScan(string $scanId, array $stats): void {
+        $scan = Bean::findOne('pluginscans', 'scan_id = ?', [$scanId]);
+
+        if (!$scan) {
+            return;
+        }
+
+        $scan->status = 'completed';
+        $scan->completed_at = date('Y-m-d H:i:s');
+        $scan->repos_scanned = $stats['repos_scanned'];
+        $scan->plugins_found = $stats['plugins_found'];
+        $scan->errors_encountered = $stats['errors_encountered'];
+
+        Bean::store($scan);
+
+        $this->logger->info("Plugin scan completed", [
+            'scan_id' => $scanId,
+            'repos_scanned' => $stats['repos_scanned'],
+            'plugins_found' => $stats['plugins_found'],
+            'errors' => $stats['errors_encountered']
+        ]);
+    }
+
+    /**
+     * Mark a scan as failed
+     *
+     * @param string $scanId Scan ID
+     * @param string $errorMessage Error message
+     */
+    public function failScan(string $scanId, string $errorMessage): void {
+        $scan = Bean::findOne('pluginscans', 'scan_id = ?', [$scanId]);
+
+        if (!$scan) {
+            return;
+        }
+
+        $scan->status = 'failed';
+        $scan->completed_at = date('Y-m-d H:i:s');
+        $scan->error_message = $errorMessage;
+
+        Bean::store($scan);
+
+        $this->logger->error("Plugin scan failed", [
+            'scan_id' => $scanId,
+            'error' => $errorMessage
+        ]);
+    }
+
+    /**
+     * Get scan history
+     *
+     * @param int $limit Number of scans to return
+     * @return array Scan records
+     */
+    public function getScanHistory(int $limit = 20): array {
+        $scans = Bean::find('pluginscans', 'ORDER BY created_at DESC LIMIT ?', [$limit]);
+
+        $result = [];
+        foreach ($scans as $scan) {
+            $result[] = $scan->export();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get all discovered plugins
+     *
+     * @param string|null $status Filter by status
+     * @return array Plugin records
+     */
+    public function getDiscoveredPlugins(?string $status = null): array {
+        if ($status) {
+            $plugins = Bean::find('discoveredplugins', 'status = ? ORDER BY discovered_at DESC', [$status]);
+        } else {
+            $plugins = Bean::find('discoveredplugins', 'ORDER BY discovered_at DESC');
+        }
+
+        $result = [];
+        foreach ($plugins as $plugin) {
+            $pluginData = $plugin->export();
+            // Parse JSON fields
+            $pluginData['plugin_requires'] = json_decode($plugin->plugin_requires, true);
+            $pluginData['plugin_json'] = json_decode($plugin->plugin_json, true);
+            $result[] = $pluginData;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get a single plugin by ID
+     *
+     * @param int $id Plugin record ID
+     * @return array|null Plugin data or null if not found
+     */
+    public function getPlugin(int $id): ?array {
+        $plugin = Bean::load('discoveredplugins', $id);
+
+        if (!$plugin || !$plugin->id) {
+            return null;
+        }
+
+        $data = $plugin->export();
+        $data['plugin_requires'] = json_decode($plugin->plugin_requires, true);
+        $data['plugin_json'] = json_decode($plugin->plugin_json, true);
+
+        return $data;
+    }
+
+    /**
+     * Handle rate limit with exponential backoff
+     *
+     * @param int $attempt Current retry attempt (1-based)
+     */
+    private function handleRateLimit(int $attempt): void {
+        $delayMs = self::INITIAL_BACKOFF_MS * pow(2, $attempt - 1);
+        $delaySec = $delayMs / 1000;
+
+        $this->logger->warning("Rate limit hit, backing off", [
+            'attempt' => $attempt,
+            'delay_seconds' => $delaySec
+        ]);
+
+        $this->log("Rate limit hit, waiting {$delaySec}s before retry...");
+
+        usleep($delayMs * 1000); // usleep takes microseconds
+    }
+
+    /**
+     * Log message to console if verbose mode is enabled
+     *
+     * @param string $message Message to log
+     */
+    private function log(string $message): void {
+        if ($this->verbose) {
+            echo "[" . date('Y-m-d H:i:s') . "] {$message}\n";
+        }
+
+        $this->logger->info($message);
+    }
+}

--- a/sql/tenant_schema.sql
+++ b/sql/tenant_schema.sql
@@ -676,4 +676,78 @@ INSERT INTO `authcontrol` (`control`, `method`, `level`, `description`) VALUES
 ('webhook', 'mailgun', 101, 'Mailgun incoming email webhook')
 ON DUPLICATE KEY UPDATE `level` = VALUES(`level`);
 
+-- ============================================================================
+-- PLUGIN DISCOVERY TABLES
+-- ============================================================================
+
+-- Discovered plugins from repository scans
+CREATE TABLE IF NOT EXISTS `discoveredplugins` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `plugin_id` VARCHAR(64) NOT NULL UNIQUE,
+    `repo_connection_id` INT NOT NULL,
+    `repo_owner` VARCHAR(100) NOT NULL,
+    `repo_name` VARCHAR(100) NOT NULL,
+
+    -- Plugin metadata from plugin.json
+    `plugin_name` VARCHAR(255),
+    `plugin_description` TEXT,
+    `plugin_version` VARCHAR(50),
+    `plugin_author` VARCHAR(255),
+    `plugin_main` VARCHAR(500),
+    `plugin_requires` JSON,
+    `plugin_json` JSON,
+
+    -- Status tracking
+    `status` ENUM('discovered', 'validated', 'invalid', 'installed') DEFAULT 'discovered',
+    `validation_error` TEXT,
+
+    -- Timestamps
+    `discovered_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `last_scanned_at` DATETIME,
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME ON UPDATE CURRENT_TIMESTAMP,
+
+    INDEX `idx_repo_connection` (`repo_connection_id`),
+    INDEX `idx_status` (`status`),
+    INDEX `idx_plugin_id` (`plugin_id`),
+    FOREIGN KEY (`repo_connection_id`) REFERENCES `repoconnections`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Plugin scan history
+CREATE TABLE IF NOT EXISTS `pluginscans` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `scan_id` VARCHAR(64) NOT NULL UNIQUE,
+    `repo_connection_id` INT DEFAULT NULL,
+
+    -- Scan status
+    `status` ENUM('running', 'completed', 'failed') DEFAULT 'running',
+
+    -- Statistics
+    `repos_scanned` INT DEFAULT 0,
+    `plugins_found` INT DEFAULT 0,
+    `errors_encountered` INT DEFAULT 0,
+
+    -- Timestamps
+    `started_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `completed_at` DATETIME,
+
+    -- Error tracking
+    `error_message` TEXT,
+
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX `idx_status` (`status`),
+    INDEX `idx_scan_id` (`scan_id`),
+    INDEX `idx_repo_connection` (`repo_connection_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Add authcontrol entries for PluginRegistry controller
+INSERT INTO `authcontrol` (`control`, `method`, `level`, `description`) VALUES
+('pluginregistry', 'index', 100, 'List discovered plugins'),
+('pluginregistry', 'scan', 100, 'Trigger plugin scan'),
+('pluginregistry', 'scanRepo', 100, 'Scan single repository'),
+('pluginregistry', 'scans', 100, 'View scan history'),
+('pluginregistry', 'view', 100, 'View plugin details')
+ON DUPLICATE KEY UPDATE `level` = VALUES(`level`);
+
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## Summary

Implements automated scanning of configured repository sources to discover plugins based on `plugin.json` markers (Issue #100).

- **Database schema**: Added `discoveredplugins` and `pluginscans` tables to track discovered plugins and scan history
- **PluginScannerService**: Core service with exponential backoff for GitHub API rate limits, plugin.json parsing, and database persistence
- **PluginRegistry controller**: Web endpoints for listing plugins, triggering scans, viewing scan history, and plugin details
- **CLI script**: `scripts/scan-plugins.php` for background/cron-based scanning with tenant support

### Key Features
- Scans all enabled `repoconnections` for `plugin.json` in repository root
- Parses and validates plugin metadata (name, version, description, author, main, requires)
- Implements exponential backoff (1s, 2s, 4s) for rate limit handling (max 3 retries)
- Tracks scan history with statistics (repos scanned, plugins found, errors)
- Supports single-repo and full-scan modes via both web UI and CLI

### Endpoints Added
- `GET /plugins` - List discovered plugins
- `POST /plugins/scan` - Trigger full scan
- `POST /plugins/scan/{id}` - Scan single repository
- `GET /plugins/scans` - View scan history
- `GET /plugins/{id}` - View plugin details

Closes #100

## Test plan
- [ ] Run database migration to create new tables
- [ ] Test CLI scan: `php scripts/scan-plugins.php --script --secret=KEY --verbose`
- [ ] Test single repo scan via CLI: `php scripts/scan-plugins.php --script --secret=KEY --repo-id=1 --verbose`
- [ ] Verify rate limit handling by running multiple scans in succession
- [ ] Test web endpoints require authentication
- [ ] Verify plugin.json parsing with valid and invalid JSON files