### PR TITLE
Studio orchestration improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # Configuration files with sensitive data
-/conf/config.ini
-/conf/config.*.ini
-/conf/mailgun.ini
-/conf/stripe.ini
-/conf/atlassian.ini
+conf/jobexecutor.ini
+conf/config.ini
+conf/config.*.ini
+conf/mailgun.ini
+conf/stripe.ini
+conf/atlassian.ini
 config.ini
 stripe
 storage
@@ -114,3 +115,4 @@ Desktop.ini
 sql/
 database/
 conf/github.ini
+conf/jobexecutor.ini

--- a/conf/jobexecutor.example.ini
+++ b/conf/jobexecutor.example.ini
@@ -1,10 +1,13 @@
 [jobexecutor]
 ; Job-executor service URL for running AI Developer jobs on remote workstations
 ; This is the default/public URL - workspaces can override in their config.{workspace}.ini
-url = "https://jobs.myctobot.ai"
+url = "https://jobs.myctobot.com"
 
 ; API timeout in seconds
 timeout = 30
 
 ; Enable/disable job-executor integration (set to false to use local tmux only)
 enabled = true
+
+; Skip SSL certificate verification (for localhost development with self-signed certs)
+verify_ssl = true

--- a/controls/Admin.php
+++ b/controls/Admin.php
@@ -1059,7 +1059,9 @@ class Admin extends Control {
 
             // Submit to job-executor (PING)
             $submitUrl = rtrim($jobExecutorUrl, '/') . '/api/jobs/submit';
-            $callbackUrl = Flight::get('baseurl') . '/api/jobexecutor';
+            // Build callback URL with workspace subdomain from site config
+            $callbackUrl = \app\services\SiteConfig::getWorkspaceUrl($workspaceSlug) . '/api/jobexecutor';
+            $verifySsl = \app\services\JobExecutorConfig::shouldVerifySsl();
 
             $ch = curl_init($submitUrl);
             curl_setopt_array($ch, [
@@ -1076,6 +1078,8 @@ class Admin extends Control {
                 ]),
                 CURLOPT_TIMEOUT => 30,
                 CURLOPT_CONNECTTIMEOUT => 10,
+                CURLOPT_SSL_VERIFYPEER => $verifySsl,
+                CURLOPT_SSL_VERIFYHOST => $verifySsl ? 2 : 0,
             ]);
 
             $response = curl_exec($ch);
@@ -1300,7 +1304,9 @@ class Admin extends Control {
 
             // Step 2: Submit to job-executor (PING)
             $submitUrl = rtrim($jobExecutorUrl, '/') . '/api/jobs/submit';
-            $callbackUrl = Flight::get('baseurl') . '/api/jobexecutor';
+            // Build callback URL with workspace subdomain from site config
+            $callbackUrl = \app\services\SiteConfig::getWorkspaceUrl($workspaceSlug) . '/api/jobexecutor';
+            $verifySsl = \app\services\JobExecutorConfig::shouldVerifySsl();
 
             $ch = curl_init($submitUrl);
             curl_setopt_array($ch, [
@@ -1317,6 +1323,8 @@ class Admin extends Control {
                 ]),
                 CURLOPT_TIMEOUT => 30,
                 CURLOPT_CONNECTTIMEOUT => 10,
+                CURLOPT_SSL_VERIFYPEER => $verifySsl,
+                CURLOPT_SSL_VERIFYHOST => $verifySsl ? 2 : 0,
             ]);
 
             $response = curl_exec($ch);

--- a/controls/Admin.php
+++ b/controls/Admin.php
@@ -1045,7 +1045,7 @@ class Admin extends Control {
             $job->issue_key = 'TEST-AGENT-001';
             $job->status = 'pending';
             $job->phase = 'agent-test';
-            $job->prompt = 'Hello! Please respond with a brief greeting to confirm you are working. Include the current directory path in your response.';
+            $job->prompt = 'Hello! Please respond with a brief greeting to confirm you are working. Include the current directory path in your response. Then run /exit to complete this test.';
             $job->delay = $delay;  // Optional delay for testing
             $job->created_at = date('Y-m-d H:i:s');
             Bean::store($job);

--- a/controls/Admin.php
+++ b/controls/Admin.php
@@ -1045,9 +1045,25 @@ class Admin extends Control {
             $job->issue_key = 'TEST-AGENT-001';
             $job->status = 'pending';
             $job->phase = 'agent-test';
-            $job->prompt = 'Hello! Please respond with a brief greeting to confirm you are working. Include the current directory path in your response.';
+            $job->prompt = 'Hello! Please respond with a brief greeting to confirm you are working. Include the current directory path in your response. After responding, call the `job_complete` MCP tool with success=true and summary="Test completed successfully" to mark this test as complete.';
             $job->delay = $delay;  // Optional delay for testing
             $job->created_at = date('Y-m-d H:i:s');
+
+            // Start with agent's existing MCP config and add myctobot jobs server
+            $mcpConfig = json_decode($agent->mcp_config ?: '{"mcpServers":{}}', true);
+            if (!isset($mcpConfig['mcpServers'])) {
+                $mcpConfig['mcpServers'] = [];
+            }
+            // Add myctobot jobs server for test completion
+            $mcpConfig['mcpServers']['myctobot'] = [
+                'type' => 'http',
+                'url' => \app\services\SiteConfig::getWorkspaceUrl($workspaceSlug) . '/mcp/jobs',
+                'headers' => [
+                    'Authorization' => 'Basic ' . base64_encode($this->member->id . ':' . $jobUid)
+                ]
+            ];
+            $job->mcp_config_json = json_encode($mcpConfig);
+
             Bean::store($job);
 
             Flight::get('log')->info('Created agent test job for job-executor', [

--- a/controls/Admin.php
+++ b/controls/Admin.php
@@ -1139,6 +1139,7 @@ class Admin extends Control {
      */
     public function teststatus($params = []) {
         $testId = $this->opId() ?? $this->getParam('test_id') ?? '';
+        $sendExit = $this->getParam('send_exit') === '1' || $this->getParam('send_exit') === 'true';
 
         if (empty($testId)) {
             $this->json(['success' => false, 'error' => 'Test ID is required']);
@@ -1205,6 +1206,13 @@ class Admin extends Control {
                 $response['phase'] = $phase;
             }
 
+            // Send /exit to tmux session if requested
+            if ($sendExit && $job->job_uid) {
+                $exitResult = $this->sendExitToJobExecutor($job->job_uid);
+                $response['exit_sent'] = $exitResult['success'] ?? false;
+                $response['exit_message'] = $exitResult['message'] ?? $exitResult['error'] ?? null;
+            }
+
             $this->json($response);
             return;
         }
@@ -1225,6 +1233,59 @@ class Admin extends Control {
         }
 
         $this->json(array_merge(['success' => true], $status));
+    }
+
+    /**
+     * Send /exit command to job-executor to stop a tmux session
+     *
+     * @param string $jobUid The job UID
+     * @return array Result with success/error
+     */
+    private function sendExitToJobExecutor(string $jobUid): array {
+        $workspaceSlug = $_SESSION['workspace_slug'] ?? 'default';
+        $jobExecutorUrl = \app\services\JobExecutorConfig::getUrl();
+        $verifySsl = \app\services\JobExecutorConfig::shouldVerifySsl();
+
+        $exitUrl = rtrim($jobExecutorUrl, '/') . '/api/jobs/exit';
+
+        $ch = curl_init($exitUrl);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'Accept: application/json',
+            ],
+            CURLOPT_POSTFIELDS => json_encode([
+                'workspace' => $workspaceSlug,
+                'job_uid' => $jobUid,
+            ]),
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_CONNECTTIMEOUT => 5,
+            CURLOPT_SSL_VERIFYPEER => $verifySsl,
+            CURLOPT_SSL_VERIFYHOST => $verifySsl ? 2 : 0,
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_error($ch);
+        curl_close($ch);
+
+        if ($curlError) {
+            Flight::get('log')->warning('Failed to send exit to job-executor', [
+                'error' => $curlError,
+                'job_uid' => $jobUid,
+            ]);
+            return ['success' => false, 'error' => "Connection failed: {$curlError}"];
+        }
+
+        $result = json_decode($response, true) ?? [];
+
+        if ($httpCode !== 200) {
+            return ['success' => false, 'error' => $result['error'] ?? "HTTP {$httpCode}"];
+        }
+
+        return $result;
     }
 
     /**

--- a/controls/Admin.php
+++ b/controls/Admin.php
@@ -1045,7 +1045,7 @@ class Admin extends Control {
             $job->issue_key = 'TEST-AGENT-001';
             $job->status = 'pending';
             $job->phase = 'agent-test';
-            $job->prompt = 'Hello! Please respond with a brief greeting to confirm you are working. Include the current directory path in your response. Then run /exit to complete this test.';
+            $job->prompt = 'Hello! Please respond with a brief greeting to confirm you are working. Include the current directory path in your response.';
             $job->delay = $delay;  // Optional delay for testing
             $job->created_at = date('Y-m-d H:i:s');
             Bean::store($job);

--- a/controls/Agents.php
+++ b/controls/Agents.php
@@ -449,6 +449,9 @@ class Agents extends BaseControls\Control {
         $isDefault = (bool) $this->getParam('is_default', false);
         $isActive = (bool) $this->getParam('is_active', true);
 
+        // DEBUG
+        $this->logger->debug("POST data", ['post' => $_POST]);
+
         if (!empty($name)) {
             $agent->name = $name;
         }
@@ -457,6 +460,18 @@ class Agents extends BaseControls\Control {
         if (LLMProviderFactory::getProviderInfo($provider)) {
             $agent->provider = $provider;
             $agent->provider_config = json_encode($this->buildRunnerConfig($provider));
+
+            // Handle Anthropic API key assignment for claude_api provider
+            $anthropicKeyId = $this->getParam('anthropickeys_id');
+            if ($provider === 'claude_api' && $anthropicKeyId) {
+                $key = Bean::load('anthropickeys', (int)$anthropicKeyId);
+                if ($key->id) {
+                    $agent->anthropickeys_id = (int)$anthropicKeyId;
+                }
+            } elseif ($provider !== 'claude_api') {
+                // Clear key assignment if switching away from claude_api
+                $agent->anthropickeys_id = null;
+            }
         }
 
         $agent->is_active = $isActive ? 1 : 0;

--- a/services/JobExecutorConfig.php
+++ b/services/JobExecutorConfig.php
@@ -40,6 +40,7 @@ class JobExecutorConfig {
             'url' => null,
             'timeout' => 30,
             'enabled' => true,
+            'verify_ssl' => true,
         ];
 
         $basePath = defined('BASE_PATH') ? BASE_PATH : dirname(__DIR__);
@@ -50,7 +51,8 @@ class JobExecutorConfig {
             $baseConfig = parse_ini_file($jobexecutorIni, true);
             if ($baseConfig && isset($baseConfig['jobexecutor'])) {
                 foreach ($baseConfig['jobexecutor'] as $key => $value) {
-                    if ($value !== '' && $value !== null) {
+                    // Note: For booleans, INI 'false' becomes '' - handled by Flight::isOn() later
+                    if ($value !== null) {
                         $config[$key] = $value;
                     }
                 }
@@ -64,7 +66,8 @@ class JobExecutorConfig {
                 $workspaceConfig = parse_ini_file($workspaceIni, true);
                 if ($workspaceConfig && isset($workspaceConfig['jobexecutor'])) {
                     foreach ($workspaceConfig['jobexecutor'] as $key => $value) {
-                        if ($value !== '' && $value !== null) {
+                        // Note: For booleans, INI 'false' becomes '' - handled by Flight::isOn() later
+                        if ($value !== null) {
                             $config[$key] = $value;
                         }
                     }
@@ -77,10 +80,9 @@ class JobExecutorConfig {
             $config['url'] = Flight::get('job_executor_url') ?? 'http://localhost:8081';
         }
 
-        // Normalize boolean for enabled
-        if (is_string($config['enabled'])) {
-            $config['enabled'] = filter_var($config['enabled'], FILTER_VALIDATE_BOOLEAN);
-        }
+        // Normalize booleans using Flight::isOn() for consistent INI parsing
+        $config['enabled'] = Flight::isOn($config['enabled']);
+        $config['verify_ssl'] = Flight::isOn($config['verify_ssl']);
 
         // Normalize timeout to int
         $config['timeout'] = (int) $config['timeout'];
@@ -122,6 +124,16 @@ class JobExecutorConfig {
      */
     public static function isEnabled(?string $workspaceSlug = null): bool {
         return self::getConfig($workspaceSlug)['enabled'];
+    }
+
+    /**
+     * Check if SSL verification should be performed
+     *
+     * @param string|null $workspaceSlug Optional workspace slug
+     * @return bool Whether to verify SSL certificates
+     */
+    public static function shouldVerifySsl(?string $workspaceSlug = null): bool {
+        return self::getConfig($workspaceSlug)['verify_ssl'];
     }
 
     /**

--- a/services/PipelineExecutor.php
+++ b/services/PipelineExecutor.php
@@ -15,6 +15,7 @@ namespace app\services;
 use \app\Bean;
 use \RedBeanPHP\R as R;
 use \app\services\AnthropicKeyService;
+use \app\services\LLMProviders\OllamaProvider;
 
 /**
  * Exception thrown when a pipeline pauses for user input in interactive mode
@@ -1390,15 +1391,17 @@ class PipelineExecutor {
      *   agent_id       - Required: ID from aiagents table
      *   prompt         - The prompt to send (supports variable substitution)
      *   system_prompt  - Optional system prompt override
-     *   model          - Optional model override (default: claude-sonnet-4-20250514)
+     *   model          - Optional model override (uses agent's configured model if not specified)
      *   max_tokens     - Optional max tokens (default: 4096)
      *   include_input  - Whether to include step input in the prompt (default: true)
+     *
+     * The agent's provider and provider_config determine which LLM backend is used.
+     * Supported providers: ollama, claude_cli (with optional use_ollama), claude_api
      */
     private function executeAIAgent(array $config, array $input, int $timeout): array {
         $agentId = $config['agent_id'] ?? null;
         $prompt = $config['prompt'] ?? '';
         $systemPrompt = $config['system_prompt'] ?? 'You are a helpful assistant processing pipeline data. Analyze the input and respond with structured JSON when appropriate.';
-        $model = $config['model'] ?? 'claude-sonnet-4-20250514';
         $maxTokens = (int)($config['max_tokens'] ?? 4096);
         $includeInput = $config['include_input'] ?? true;
 
@@ -1412,12 +1415,9 @@ class PipelineExecutor {
             return ['success' => false, 'error' => 'Agent not found'];
         }
 
-        // Get API key
-        $memberId = $this->run->member_id ?? 1;
-        $apiKey = AnthropicKeyService::getApiKeyForAgent($agent, $memberId);
-        if (empty($apiKey)) {
-            return ['success' => false, 'error' => 'No Anthropic API key available'];
-        }
+        // Get agent's provider configuration
+        $provider = $agent->provider ?: 'claude_api';
+        $providerConfig = json_decode($agent->provider_config ?: '{}', true);
 
         // Substitute variables in prompts
         $prompt = $this->substituteVariables($prompt);
@@ -1431,9 +1431,151 @@ class PipelineExecutor {
         }
 
         $this->log('info', "Executing AI agent: {$agent->name}", [
-            'model' => $model,
+            'provider' => $provider,
+            'provider_config' => $providerConfig,
             'prompt_length' => strlen($userMessage)
         ]);
+
+        // Route to appropriate provider based on agent configuration
+        try {
+            // Check for Ollama provider (direct or via claude_cli with use_ollama)
+            $useOllama = ($provider === 'ollama') ||
+                         ($provider === 'claude_cli' && !empty($providerConfig['use_ollama']));
+
+            if ($useOllama) {
+                return $this->executeOllamaAgent($agent, $provider, $providerConfig, $userMessage, $systemPrompt, $timeout);
+            }
+
+            // Claude API provider
+            if ($provider === 'claude_api') {
+                $model = $config['model'] ?? $providerConfig['model'] ?? 'claude-sonnet-4-20250514';
+                return $this->executeClaudeApiAgent($agent, $model, $userMessage, $systemPrompt, $maxTokens, $timeout);
+            }
+
+            // claude_cli without use_ollama - this requires the Claude CLI which isn't available in pipeline context
+            if ($provider === 'claude_cli') {
+                return [
+                    'success' => false,
+                    'error' => "Agent '{$agent->name}' is configured to use Claude CLI, but claude_cli provider requires " .
+                               "either 'use_ollama' to be enabled in provider config, or switch the agent to 'claude_api' " .
+                               "or 'ollama' provider for pipeline execution."
+                ];
+            }
+
+            // Unsupported provider
+            return [
+                'success' => false,
+                'error' => "Unsupported provider '{$provider}' for agent '{$agent->name}'. " .
+                           "Supported providers for pipelines: ollama, claude_api, claude_cli (with use_ollama enabled)"
+            ];
+
+        } catch (\Exception $e) {
+            $this->log('error', "AI agent exception: {$e->getMessage()}");
+            return ['success' => false, 'error' => "AI agent exception: {$e->getMessage()}"];
+        }
+    }
+
+    /**
+     * Execute agent using Ollama provider
+     */
+    private function executeOllamaAgent($agent, string $provider, array $providerConfig, string $userMessage, string $systemPrompt, int $timeout): array {
+        // Determine host and model based on provider type
+        if ($provider === 'ollama') {
+            $ollamaHost = $providerConfig['host'] ?? $providerConfig['base_url'] ?? 'http://localhost:11434';
+            $ollamaModel = $providerConfig['model'] ?? '';
+        } else {
+            // claude_cli with use_ollama
+            $ollamaHost = $providerConfig['ollama_host'] ?? 'http://localhost:11434';
+            $ollamaModel = $providerConfig['ollama_model'] ?? '';
+        }
+
+        if (empty($ollamaModel)) {
+            return [
+                'success' => false,
+                'error' => "Agent '{$agent->name}' has Ollama enabled but no model specified in provider_config. " .
+                           "Please configure ollama_model (for claude_cli) or model (for ollama provider)."
+            ];
+        }
+
+        $this->log('info', "Using Ollama provider", [
+            'host' => $ollamaHost,
+            'model' => $ollamaModel
+        ]);
+
+        try {
+            // Use OllamaProvider for the request
+            $ollamaProvider = new OllamaProvider([
+                'host' => $ollamaHost,
+                'model' => $ollamaModel
+            ]);
+
+            // Use chat API with system prompt
+            $messages = [
+                ['role' => 'system', 'content' => $systemPrompt],
+                ['role' => 'user', 'content' => $userMessage]
+            ];
+
+            $result = $ollamaProvider->chat($messages, [
+                'model' => $ollamaModel
+            ]);
+
+            if (!$result['success']) {
+                return [
+                    'success' => false,
+                    'error' => "Ollama request failed: " . ($result['error'] ?? 'Unknown error')
+                ];
+            }
+
+            $content = $result['response'] ?? '';
+
+            // Try to parse response as JSON
+            $parsed = null;
+            if (preg_match('/```json\s*([\s\S]*?)\s*```/', $content, $matches)) {
+                $parsed = json_decode($matches[1], true);
+            } elseif (str_starts_with(trim($content), '{') || str_starts_with(trim($content), '[')) {
+                $parsed = json_decode($content, true);
+            }
+
+            $this->log('info', "Ollama agent completed", [
+                'response_length' => strlen($content),
+                'has_json' => $parsed !== null
+            ]);
+
+            return [
+                'success' => true,
+                'output' => [
+                    'agent_id' => $agent->id,
+                    'agent_name' => $agent->name,
+                    'provider' => 'ollama',
+                    'model' => $ollamaModel,
+                    'response' => $content,
+                    'parsed' => $parsed,
+                    'usage' => $result['usage'] ?? null
+                ]
+            ];
+
+        } catch (\Exception $e) {
+            $this->log('error', "Ollama agent failed: {$e->getMessage()}");
+            return ['success' => false, 'error' => "Ollama error: {$e->getMessage()}"];
+        }
+    }
+
+    /**
+     * Execute agent using Claude API (Anthropic)
+     */
+    private function executeClaudeApiAgent($agent, string $model, string $userMessage, string $systemPrompt, int $maxTokens, int $timeout): array {
+        $memberId = $this->run->member_id ?? 1;
+        $apiKey = AnthropicKeyService::getApiKeyForAgent($agent, $memberId);
+
+        if (empty($apiKey)) {
+            return [
+                'success' => false,
+                'error' => "Agent '{$agent->name}' is configured to use Claude API but no Anthropic API key is available. " .
+                           "Please assign an API key to this agent or switch to a different provider."
+            ];
+        }
+
+        $this->log('info', "Using Claude API provider", ['model' => $model]);
 
         try {
             $client = new \GuzzleHttp\Client([
@@ -1468,7 +1610,7 @@ class PipelineExecutor {
                 $parsed = json_decode($content, true);
             }
 
-            $this->log('info', "AI agent completed", [
+            $this->log('info', "Claude API agent completed", [
                 'response_length' => strlen($content),
                 'has_json' => $parsed !== null
             ]);
@@ -1476,8 +1618,9 @@ class PipelineExecutor {
             return [
                 'success' => true,
                 'output' => [
-                    'agent_id' => $agentId,
+                    'agent_id' => $agent->id,
                     'agent_name' => $agent->name,
+                    'provider' => 'claude_api',
                     'model' => $model,
                     'response' => $content,
                     'parsed' => $parsed,
@@ -1491,12 +1634,8 @@ class PipelineExecutor {
                 $errorBody = json_decode($e->getResponse()->getBody()->getContents(), true);
                 $errorMessage = $errorBody['error']['message'] ?? $errorMessage;
             }
-            $this->log('error', "AI agent failed: {$errorMessage}");
-            return ['success' => false, 'error' => "AI agent error: {$errorMessage}"];
-
-        } catch (\Exception $e) {
-            $this->log('error', "AI agent exception: {$e->getMessage()}");
-            return ['success' => false, 'error' => "AI agent exception: {$e->getMessage()}"];
+            $this->log('error', "Claude API agent failed: {$errorMessage}");
+            return ['success' => false, 'error' => "Claude API error: {$errorMessage}"];
         }
     }
 

--- a/views/admin/runner_form.php
+++ b/views/admin/runner_form.php
@@ -658,6 +658,9 @@ async function pollWsTestStatus(originalBtnHtml) {
         clearInterval(wsPollInterval);
         wsPollInterval = null;
 
+        // Wait 5 seconds for agent to finish, then send exit
+        await new Promise(resolve => setTimeout(resolve, 5000));
+
         // Send exit command to gracefully close the session
         try {
             await fetch('/admin/teststatus/' + wsCurrentTestId + '?send_exit=1');

--- a/views/admin/runner_form.php
+++ b/views/admin/runner_form.php
@@ -654,9 +654,16 @@ async function pollWsTestStatus(originalBtnHtml) {
             return;
         }
 
-        // Test completed
+        // Test completed - send exit to clean up tmux session
         clearInterval(wsPollInterval);
         wsPollInterval = null;
+
+        // Send exit command to gracefully close the session
+        try {
+            await fetch('/admin/teststatus/' + wsCurrentTestId + '?send_exit=1');
+        } catch (e) {
+            console.warn('Failed to send exit:', e);
+        }
 
         const btn = document.querySelector('button[onclick="runTestWithAgent()"]');
         if (btn) {

--- a/views/agents/_provider_config.php
+++ b/views/agents/_provider_config.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Reusable provider configuration partial
+ *
+ * Required variables:
+ *   $prefix       - Unique prefix for element IDs (e.g., 'create', 'edit')
+ *   $provider     - Current provider type
+ *   $providerConfig - Current provider config array
+ *   $providers    - Available providers list
+ *   $anthropicKeys - Available Anthropic API keys (optional)
+ *   $agent        - Agent data array (for existing agents, optional)
+ */
+
+$prefix = $prefix ?? 'form';
+$provider = $provider ?? 'claude_cli';
+$providerConfig = $providerConfig ?? [];
+$anthropicKeys = $anthropicKeys ?? [];
+$agent = $agent ?? [];
+?>
+
+<!-- Provider Selection -->
+<div class="mb-3">
+    <label for="provider_<?= $prefix ?>" class="form-label">Provider <span class="text-danger">*</span></label>
+    <select class="form-select" id="provider_<?= $prefix ?>" name="provider" onchange="updateProviderConfig('<?= $prefix ?>')">
+        <?php foreach ($providers as $p): ?>
+        <option value="<?= $p['type'] ?>" <?= $provider === $p['type'] ? 'selected' : '' ?>>
+            <?= htmlspecialchars($p['name']) ?> - <?= htmlspecialchars($p['description']) ?>
+        </option>
+        <?php endforeach; ?>
+    </select>
+</div>
+
+<!-- Provider Config -->
+<div id="<?= $prefix ?>-provider-config" class="mb-3">
+    <!-- Claude CLI Config -->
+    <div class="provider-config-<?= $prefix ?>" id="<?= $prefix ?>-config-claude_cli" style="display: <?= $provider === 'claude_cli' ? 'block' : 'none' ?>;">
+        <div class="card bg-light">
+            <div class="card-body">
+                <h6><i class="bi bi-terminal"></i> Claude CLI Settings</h6>
+                <div class="form-check form-switch mb-2">
+                    <input class="form-check-input" type="checkbox" id="<?= $prefix ?>-use-ollama" name="use_ollama"
+                           <?= !empty($providerConfig['use_ollama']) ? 'checked' : '' ?>
+                           <?= $provider !== 'claude_cli' ? 'disabled' : '' ?>
+                           onchange="toggleClaudeBackend('<?= $prefix ?>')">
+                    <label class="form-check-label" for="<?= $prefix ?>-use-ollama">
+                        <i class="bi bi-cpu"></i> Use Ollama as backend
+                    </label>
+                </div>
+                <div id="<?= $prefix ?>-claude-anthropic" style="display: <?= empty($providerConfig['use_ollama']) ? 'block' : 'none' ?>;">
+                    <label class="form-label">Model</label>
+                    <select class="form-select provider-model-field" name="model" <?= $provider !== 'claude_cli' ? 'disabled' : '' ?>>
+                        <option value="sonnet" <?= ($providerConfig['model'] ?? 'sonnet') === 'sonnet' ? 'selected' : '' ?>>Sonnet (Recommended)</option>
+                        <option value="opus" <?= ($providerConfig['model'] ?? '') === 'opus' ? 'selected' : '' ?>>Opus</option>
+                        <option value="haiku" <?= ($providerConfig['model'] ?? '') === 'haiku' ? 'selected' : '' ?>>Haiku (Fast)</option>
+                    </select>
+                </div>
+                <div id="<?= $prefix ?>-claude-ollama" style="display: <?= !empty($providerConfig['use_ollama']) ? 'block' : 'none' ?>;">
+                    <div class="mb-2">
+                        <label class="form-label">Ollama Host</label>
+                        <div class="input-group">
+                            <input type="text" class="form-control" id="<?= $prefix ?>-ollama-host" name="ollama_host"
+                                   value="<?= htmlspecialchars($providerConfig['ollama_host'] ?? 'http://localhost:11434') ?>"
+                                   placeholder="http://localhost:11434">
+                            <button type="button" class="btn btn-outline-primary" onclick="loadOllamaModels('<?= $prefix ?>')">
+                                <i class="bi bi-arrow-clockwise"></i> Load Models
+                            </button>
+                        </div>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">Ollama Model</label>
+                        <select class="form-select" id="<?= $prefix ?>-ollama-model" name="ollama_model">
+                            <?php if (!empty($providerConfig['ollama_model'])): ?>
+                            <option value="<?= htmlspecialchars($providerConfig['ollama_model']) ?>" selected>
+                                <?= htmlspecialchars($providerConfig['ollama_model']) ?>
+                            </option>
+                            <?php else: ?>
+                            <option value="">-- Click "Load Models" to fetch --</option>
+                            <?php endif; ?>
+                        </select>
+                        <div class="form-text">
+                            Recommended: <code>qwen3-coder</code>, <code>codellama</code>, <code>llama3</code>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Ollama Direct Config -->
+    <div class="provider-config-<?= $prefix ?>" id="<?= $prefix ?>-config-ollama" style="display: <?= $provider === 'ollama' ? 'block' : 'none' ?>;">
+        <div class="card bg-light">
+            <div class="card-body">
+                <h6><i class="bi bi-cpu"></i> Ollama Settings</h6>
+                <div class="mb-2">
+                    <label class="form-label">Ollama Host</label>
+                    <div class="input-group">
+                        <input type="text" class="form-control" id="<?= $prefix ?>-ollama-direct-host" name="base_url"
+                               value="<?= htmlspecialchars($providerConfig['base_url'] ?? $providerConfig['host'] ?? 'http://localhost:11434') ?>"
+                               placeholder="http://localhost:11434"
+                               <?= $provider !== 'ollama' ? 'disabled' : '' ?>>
+                        <button type="button" class="btn btn-outline-primary" onclick="loadOllamaModels('<?= $prefix ?>', true)">
+                            <i class="bi bi-arrow-clockwise"></i> Load Models
+                        </button>
+                    </div>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label">Ollama Model</label>
+                    <select class="form-select provider-model-field" id="<?= $prefix ?>-ollama-direct-model" name="model" <?= $provider !== 'ollama' ? 'disabled' : '' ?>>
+                        <?php if (!empty($providerConfig['model'])): ?>
+                        <option value="<?= htmlspecialchars($providerConfig['model']) ?>" selected>
+                            <?= htmlspecialchars($providerConfig['model']) ?>
+                        </option>
+                        <?php else: ?>
+                        <option value="">-- Click "Load Models" to fetch --</option>
+                        <?php endif; ?>
+                    </select>
+                    <div class="form-text">
+                        Recommended: <code>llama3.2</code>, <code>qwen3-coder</code>, <code>codellama</code>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- OpenAI Config -->
+    <div class="provider-config-<?= $prefix ?>" id="<?= $prefix ?>-config-openai" style="display: <?= $provider === 'openai' ? 'block' : 'none' ?>;">
+        <div class="card bg-light">
+            <div class="card-body">
+                <h6><i class="bi bi-stars"></i> OpenAI Settings</h6>
+                <div class="mb-2">
+                    <label class="form-label">Model</label>
+                    <select class="form-select provider-model-field" name="model" <?= $provider !== 'openai' ? 'disabled' : '' ?>>
+                        <option value="gpt-4-turbo" <?= ($providerConfig['model'] ?? 'gpt-4-turbo') === 'gpt-4-turbo' ? 'selected' : '' ?>>GPT-4 Turbo</option>
+                        <option value="gpt-4o" <?= ($providerConfig['model'] ?? '') === 'gpt-4o' ? 'selected' : '' ?>>GPT-4o</option>
+                        <option value="gpt-4o-mini" <?= ($providerConfig['model'] ?? '') === 'gpt-4o-mini' ? 'selected' : '' ?>>GPT-4o Mini</option>
+                    </select>
+                </div>
+                <div class="form-text">API key is configured in Settings &rarr; Connections</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Claude API Config -->
+    <div class="provider-config-<?= $prefix ?>" id="<?= $prefix ?>-config-claude_api" style="display: <?= $provider === 'claude_api' ? 'block' : 'none' ?>;">
+        <div class="card bg-light">
+            <div class="card-body">
+                <h6><i class="bi bi-cloud"></i> Claude API Settings</h6>
+
+                <div class="mb-3">
+                    <label class="form-label">Anthropic API Key <span class="text-danger">*</span></label>
+                    <select class="form-select" name="anthropickeys_id" id="<?= $prefix ?>_anthropickeys_id">
+                        <option value="">-- Select API Key --</option>
+                        <?php if (!empty($anthropicKeys)): ?>
+                            <?php foreach ($anthropicKeys as $key): ?>
+                            <option value="<?= $key->id ?>"
+                                    <?= ($agent['anthropickeys_id'] ?? null) == $key->id ? 'selected' : '' ?>
+                                    data-model="<?= htmlspecialchars($key->model ?? '') ?>">
+                                <?= htmlspecialchars($key->name) ?>
+                                <?php if ($key->shared): ?>(Shared)<?php endif; ?>
+                                - <?= htmlspecialchars($key->model ?? 'default') ?>
+                            </option>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </select>
+                    <div class="form-text">
+                        Select the API key this agent will use.
+                        <a href="/anthropic/keys">Manage API Keys</a>
+                    </div>
+                </div>
+
+                <div class="mb-2">
+                    <label class="form-label">Model</label>
+                    <select class="form-select provider-model-field" name="model" <?= $provider !== 'claude_api' ? 'disabled' : '' ?>>
+                        <option value="claude-sonnet-4-20250514" <?= ($providerConfig['model'] ?? 'claude-sonnet-4-20250514') === 'claude-sonnet-4-20250514' ? 'selected' : '' ?>>Claude Sonnet 4 (Recommended)</option>
+                        <option value="claude-opus-4-20250514" <?= ($providerConfig['model'] ?? '') === 'claude-opus-4-20250514' ? 'selected' : '' ?>>Claude Opus 4</option>
+                        <option value="claude-3-5-haiku-20241022" <?= ($providerConfig['model'] ?? '') === 'claude-3-5-haiku-20241022' ? 'selected' : '' ?>>Claude 3.5 Haiku (Fast)</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Custom HTTP Config -->
+    <div class="provider-config-<?= $prefix ?>" id="<?= $prefix ?>-config-custom_http" style="display: <?= $provider === 'custom_http' ? 'block' : 'none' ?>;">
+        <div class="card bg-light">
+            <div class="card-body">
+                <h6><i class="bi bi-globe"></i> Custom HTTP Settings</h6>
+                <div class="mb-2">
+                    <label class="form-label">Endpoint URL</label>
+                    <input type="text" class="form-control provider-field" name="endpoint"
+                           value="<?= htmlspecialchars($providerConfig['endpoint'] ?? '') ?>"
+                           placeholder="https://api.example.com/v1/chat/completions"
+                           <?= $provider !== 'custom_http' ? 'disabled' : '' ?>>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label">Model</label>
+                    <input type="text" class="form-control provider-model-field" name="model"
+                           value="<?= htmlspecialchars($providerConfig['model'] ?? '') ?>"
+                           placeholder="Model name"
+                           <?= $provider !== 'custom_http' ? 'disabled' : '' ?>>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/views/agents/edit.php
+++ b/views/agents/edit.php
@@ -112,194 +112,11 @@ $mcpToolDescription = $agent['mcp_tool_description'] ?? '';
                               placeholder="Optional description of this agent's purpose"><?= htmlspecialchars($agent['description'] ?? '') ?></textarea>
                 </div>
 
-                <?php if ($isNew): ?>
-                <!-- Provider Selection for New Agent -->
-                <div class="mb-3">
-                    <label for="provider" class="form-label">Provider <span class="text-danger">*</span></label>
-                    <select class="form-select" id="provider_create" name="provider" onchange="updateCreateProviderConfig()">
-                        <?php foreach ($providers as $p): ?>
-                        <option value="<?= $p['type'] ?>" <?= $provider === $p['type'] ? 'selected' : '' ?>>
-                            <?= htmlspecialchars($p['name']) ?> - <?= htmlspecialchars($p['description']) ?>
-                        </option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-
-                <!-- Provider Config for New Agent (inline) -->
-                <div id="create-provider-config" class="mb-3">
-                    <!-- Claude CLI Config -->
-                    <div class="create-provider-config" id="create-config-claude_cli">
-                        <div class="card bg-light">
-                            <div class="card-body">
-                                <h6><i class="bi bi-terminal"></i> Claude CLI Settings</h6>
-                                <div class="form-check form-switch mb-2">
-                                    <input class="form-check-input" type="checkbox" id="create-use-ollama" name="use_ollama"
-                                           onchange="toggleCreateClaudeBackend()">
-                                    <label class="form-check-label" for="create-use-ollama">
-                                        <i class="bi bi-cpu"></i> Use Ollama as backend
-                                    </label>
-                                </div>
-                                <div id="create-claude-anthropic">
-                                    <label class="form-label">Model</label>
-                                    <select class="form-select" name="model">
-                                        <option value="sonnet" selected>Sonnet (Recommended)</option>
-                                        <option value="opus">Opus</option>
-                                        <option value="haiku">Haiku (Fast)</option>
-                                    </select>
-                                </div>
-                                <div id="create-claude-ollama" style="display:none;">
-                                    <div class="mb-2">
-                                        <label class="form-label">Ollama Host</label>
-                                        <div class="input-group">
-                                            <input type="text" class="form-control" id="create-ollama-host" name="ollama_host"
-                                                   value="http://localhost:11434" placeholder="http://localhost:11434">
-                                            <button type="button" class="btn btn-outline-primary" onclick="loadCreateOllamaModels()">
-                                                <i class="bi bi-arrow-clockwise"></i> Load Models
-                                            </button>
-                                        </div>
-                                    </div>
-                                    <div class="mb-2">
-                                        <label class="form-label">Ollama Model</label>
-                                        <select class="form-select" id="create-ollama-model" name="ollama_model">
-                                            <option value="">-- Click "Load Models" to fetch --</option>
-                                        </select>
-                                        <div class="form-text">
-                                            Recommended: <code>qwen3-coder</code>, <code>codellama</code>, <code>llama3</code>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- OpenAI Config -->
-                    <div class="create-provider-config" id="create-config-openai" style="display:none;">
-                        <div class="card bg-light">
-                            <div class="card-body">
-                                <h6><i class="bi bi-stars"></i> OpenAI Settings</h6>
-                                <div class="mb-2">
-                                    <label class="form-label">Model</label>
-                                    <select class="form-select" name="model">
-                                        <option value="gpt-4-turbo">GPT-4 Turbo</option>
-                                        <option value="gpt-4o">GPT-4o</option>
-                                        <option value="gpt-4o-mini">GPT-4o Mini</option>
-                                    </select>
-                                </div>
-                                <div class="form-text">API key is configured in Settings → Connections</div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Claude API Config -->
-                    <div class="create-provider-config" id="create-config-claude_api" style="display:none;">
-                        <div class="card bg-light">
-                            <div class="card-body">
-                                <h6><i class="bi bi-cloud"></i> Claude API Settings</h6>
-
-                                <div class="mb-3">
-                                    <label class="form-label">Anthropic API Key <span class="text-danger">*</span></label>
-                                    <select class="form-select" name="anthropickeys_id" id="create_anthropickeys_id">
-                                        <option value="">-- Select API Key --</option>
-                                        <?php if (!empty($anthropicKeys)): ?>
-                                            <?php foreach ($anthropicKeys as $key): ?>
-                                            <option value="<?= $key->id ?>"
-                                                    data-model="<?= htmlspecialchars($key->model ?? '') ?>">
-                                                <?= htmlspecialchars($key->name) ?>
-                                                <?php if ($key->shared): ?>(Shared)<?php endif; ?>
-                                                - <?= htmlspecialchars($key->model ?? 'default') ?>
-                                            </option>
-                                            <?php endforeach; ?>
-                                        <?php endif; ?>
-                                    </select>
-                                    <div class="form-text">
-                                        Select the API key this agent will use.
-                                        <a href="/anthropic/keys">Manage API Keys</a>
-                                    </div>
-                                </div>
-
-                                <div class="mb-2">
-                                    <label class="form-label">Model</label>
-                                    <select class="form-select" name="model">
-                                        <option value="claude-sonnet-4-20250514">Claude Sonnet 4 (Recommended)</option>
-                                        <option value="claude-opus-4-20250514">Claude Opus 4</option>
-                                        <option value="claude-3-5-haiku-20241022">Claude 3.5 Haiku (Fast)</option>
-                                    </select>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Custom HTTP Config -->
-                    <div class="create-provider-config" id="create-config-custom_http" style="display:none;">
-                        <div class="card bg-light">
-                            <div class="card-body">
-                                <h6><i class="bi bi-globe"></i> Custom HTTP Settings</h6>
-                                <div class="mb-2">
-                                    <label class="form-label">Endpoint URL</label>
-                                    <input type="text" class="form-control" name="endpoint"
-                                           placeholder="https://api.example.com/v1/chat/completions">
-                                </div>
-                                <div class="mb-2">
-                                    <label class="form-label">Model</label>
-                                    <input type="text" class="form-control" name="model"
-                                           placeholder="Model name">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <?php else: ?>
-                <!-- Provider Display for Existing Agent (edit on Provider tab) -->
-                <div class="mb-3">
-                    <label class="form-label">Runner & LLM Engine</label>
-                    <div class="d-flex align-items-center gap-2 flex-wrap">
-                        <?php if ($provider === 'claude_cli'): ?>
-                            <?php if (!empty($providerConfig['use_ollama'])): ?>
-                            <span class="badge bg-primary fs-6" title="Runner: Claude Code CLI">
-                                <i class="bi bi-terminal"></i> Claude CLI
-                            </span>
-                            <span class="badge bg-info text-dark fs-6" title="LLM Engine: Ollama">
-                                <i class="bi bi-cpu"></i> Ollama
-                            </span>
-                            <?php else: ?>
-                            <span class="badge bg-primary fs-6" title="Runner: Claude Code CLI">
-                                <i class="bi bi-terminal"></i> Claude CLI
-                            </span>
-                            <span class="badge bg-success fs-6" title="LLM Engine: Anthropic API">
-                                <i class="bi bi-cloud"></i> Anthropic
-                            </span>
-                            <?php endif; ?>
-                        <?php else: ?>
-                            <?php
-                            $providerName = 'Unknown';
-                            foreach ($providers as $p) {
-                                if ($p['type'] === $provider) {
-                                    $providerName = $p['name'];
-                                    break;
-                                }
-                            }
-                            ?>
-                            <span class="badge bg-secondary fs-6">
-                                <i class="bi bi-gear"></i> <?= htmlspecialchars($providerName) ?>
-                            </span>
-                        <?php endif; ?>
-                        <a href="/agents/edit/<?= $agentId ?>?tab=provider" class="btn btn-sm btn-outline-secondary">
-                            <i class="bi bi-gear"></i> Configure
-                        </a>
-                    </div>
-                </div>
-                <?php if ($provider === 'claude_cli'): ?>
-                <div class="mb-3">
-                    <label class="form-label">Model</label>
-                    <div>
-                        <?php if (!empty($providerConfig['use_ollama'])): ?>
-                        <code class="fs-6"><?= htmlspecialchars($providerConfig['ollama_model'] ?? 'not set') ?></code>
-                        <?php else: ?>
-                        <code class="fs-6"><?= htmlspecialchars($providerConfig['model'] ?? 'sonnet') ?></code>
-                        <?php endif; ?>
-                    </div>
-                </div>
-                <?php endif; ?>
+                <?php
+                // Include the shared provider config partial
+                $prefix = $isNew ? 'create' : 'edit';
+                include __DIR__ . '/_provider_config.php';
+                ?>
 
                 <!-- Provider Capabilities -->
                 <div class="mb-3">
@@ -309,7 +126,6 @@ $mcpToolDescription = $agent['mcp_tool_description'] ?? '';
                     </div>
                     <div class="form-text">Capabilities derived from the selected model</div>
                 </div>
-                <?php endif; ?>
 
                 <hr>
 
@@ -643,40 +459,61 @@ $mcpToolDescription = $agent['mcp_tool_description'] ?? '';
     </script>
     <?php endif; ?>
 
-    <?php if ($isNew): ?>
-    <!-- JavaScript for Create Form -->
+    <!-- Shared JavaScript for Provider Config (works with any prefix) -->
     <script>
-    function updateCreateProviderConfig() {
-        const provider = document.getElementById('provider_create')?.value;
+    const currentPrefix = '<?= $isNew ? 'create' : 'edit' ?>';
+
+    // Generic function to update provider config visibility and field states
+    function updateProviderConfig(prefix) {
+        const provider = document.getElementById('provider_' + prefix)?.value;
         if (!provider) return;
 
-        document.querySelectorAll('.create-provider-config').forEach(el => el.style.display = 'none');
-        const configEl = document.getElementById('create-config-' + provider);
+        // Hide all provider configs and disable their fields
+        document.querySelectorAll('.provider-config-' + prefix).forEach(el => {
+            el.style.display = 'none';
+            // Disable all fields in hidden sections so they don't submit
+            el.querySelectorAll('input, select, textarea').forEach(field => {
+                field.disabled = true;
+            });
+        });
+
+        // Show selected provider config and enable its fields
+        const configEl = document.getElementById(prefix + '-config-' + provider);
         if (configEl) {
             configEl.style.display = 'block';
+            // Enable fields in the visible section
+            configEl.querySelectorAll('input, select, textarea').forEach(field => {
+                field.disabled = false;
+            });
         }
     }
 
-    function toggleCreateClaudeBackend() {
-        const useOllama = document.getElementById('create-use-ollama')?.checked;
-        const anthropicEl = document.getElementById('create-claude-anthropic');
-        const ollamaEl = document.getElementById('create-claude-ollama');
+    // Generic function to toggle Claude backend between Anthropic and Ollama
+    function toggleClaudeBackend(prefix) {
+        const useOllama = document.getElementById(prefix + '-use-ollama')?.checked;
+        const anthropicEl = document.getElementById(prefix + '-claude-anthropic');
+        const ollamaEl = document.getElementById(prefix + '-claude-ollama');
         if (anthropicEl) anthropicEl.style.display = useOllama ? 'none' : 'block';
         if (ollamaEl) ollamaEl.style.display = useOllama ? 'block' : 'none';
 
         // Auto-load models when toggling on
         if (useOllama) {
-            loadCreateOllamaModels();
+            loadOllamaModels(prefix);
         }
     }
 
-    function loadCreateOllamaModels() {
-        const host = document.getElementById('create-ollama-host').value;
-        const modelSelect = document.getElementById('create-ollama-model');
+    // Generic function to load Ollama models
+    function loadOllamaModels(prefix, isDirect = false) {
+        const hostId = isDirect ? prefix + '-ollama-direct-host' : prefix + '-ollama-host';
+        const modelId = isDirect ? prefix + '-ollama-direct-model' : prefix + '-ollama-model';
+
+        const host = document.getElementById(hostId)?.value;
+        const modelSelect = document.getElementById(modelId);
+
+        if (!modelSelect) return;
 
         modelSelect.innerHTML = '<option value="">Loading models...</option>';
 
-        // Fetch via server (Ollama runs on same server)
         fetch('/agents/getmodels', {
             method: 'POST',
             headers: {
@@ -698,30 +535,36 @@ $mcpToolDescription = $agent['mcp_tool_description'] ?? '';
                     opt.textContent = model.name + paramInfo + sizeInfo;
                     modelSelect.appendChild(opt);
                 });
-                hideCreateOllamaManualInput();
+                hideOllamaManualInput(prefix, isDirect);
             } else {
                 modelSelect.innerHTML = '<option value="">No models found - enter manually</option>';
-                showCreateOllamaManualInput();
+                showOllamaManualInput(prefix, isDirect);
             }
         })
         .catch(e => {
             console.log('Failed to load models:', e.message);
             modelSelect.innerHTML = '<option value="">Error loading models</option>';
-            showCreateOllamaManualInput();
+            showOllamaManualInput(prefix, isDirect);
         });
     }
 
-    function showCreateOllamaManualInput() {
-        let manualDiv = document.getElementById('create-ollama-manual');
+    function showOllamaManualInput(prefix, isDirect = false) {
+        const suffix = isDirect ? '-direct' : '';
+        const manualId = prefix + '-ollama' + suffix + '-manual';
+        const modelId = prefix + '-ollama' + suffix + '-model';
+
+        let manualDiv = document.getElementById(manualId);
         if (!manualDiv) {
-            const modelDiv = document.getElementById('create-ollama-model').parentElement;
+            const modelDiv = document.getElementById(modelId)?.parentElement;
+            if (!modelDiv) return;
+
             manualDiv = document.createElement('div');
-            manualDiv.id = 'create-ollama-manual';
+            manualDiv.id = manualId;
             manualDiv.className = 'mt-2';
             manualDiv.innerHTML = `
                 <label class="form-label small text-muted">Or enter model name:</label>
-                <input type="text" class="form-control form-control-sm" id="create-ollama-model-manual"
-                       placeholder="qwen3-coder, codellama, llama3" onchange="syncManualModel()">
+                <input type="text" class="form-control form-control-sm" id="${manualId}-input"
+                       placeholder="qwen3-coder, codellama, llama3" onchange="syncManualModel('${prefix}', ${isDirect})">
                 <div class="form-text">Localhost not reachable from web - model will be validated when agent runs</div>
             `;
             modelDiv.appendChild(manualDiv);
@@ -729,16 +572,20 @@ $mcpToolDescription = $agent['mcp_tool_description'] ?? '';
         manualDiv.style.display = 'block';
     }
 
-    function hideCreateOllamaManualInput() {
-        const manualDiv = document.getElementById('create-ollama-manual');
+    function hideOllamaManualInput(prefix, isDirect = false) {
+        const suffix = isDirect ? '-direct' : '';
+        const manualDiv = document.getElementById(prefix + '-ollama' + suffix + '-manual');
         if (manualDiv) manualDiv.style.display = 'none';
     }
 
-    function syncManualModel() {
-        const manual = document.getElementById('create-ollama-model-manual');
-        const select = document.getElementById('create-ollama-model');
-        if (manual && manual.value) {
-            // Add as option and select it
+    function syncManualModel(prefix, isDirect = false) {
+        const suffix = isDirect ? '-direct' : '';
+        const manualId = prefix + '-ollama' + suffix + '-manual-input';
+        const modelId = prefix + '-ollama' + suffix + '-model';
+
+        const manual = document.getElementById(manualId);
+        const select = document.getElementById(modelId);
+        if (manual && manual.value && select) {
             const opt = document.createElement('option');
             opt.value = manual.value;
             opt.textContent = manual.value;
@@ -748,10 +595,9 @@ $mcpToolDescription = $agent['mcp_tool_description'] ?? '';
     }
 
     document.addEventListener('DOMContentLoaded', function() {
-        updateCreateProviderConfig();
+        updateProviderConfig(currentPrefix);
     });
     </script>
-    <?php endif; ?>
 
     <?php elseif ($activeTab === 'mcp'): ?>
     <!-- MCP Servers Tab -->
@@ -2244,26 +2090,6 @@ function testClaudeOllamaConnection() {
         resultEl.innerHTML = '<span class="text-danger"><i class="bi bi-x-circle"></i> Error: ' + e.message + '</span>';
         showClaudeOllamaManualInput();
     });
-}
-
-// Create form provider functions
-function updateCreateProviderConfig() {
-    const provider = document.getElementById('provider_create')?.value;
-    if (!provider) return;
-
-    document.querySelectorAll('.create-provider-config').forEach(el => el.style.display = 'none');
-    const configEl = document.getElementById('create-config-' + provider);
-    if (configEl) {
-        configEl.style.display = 'block';
-    }
-}
-
-function toggleCreateClaudeBackend() {
-    const useOllama = document.getElementById('create-use-ollama')?.checked;
-    const anthropicEl = document.getElementById('create-claude-anthropic');
-    const ollamaEl = document.getElementById('create-claude-ollama');
-    if (anthropicEl) anthropicEl.style.display = useOllama ? 'none' : 'block';
-    if (ollamaEl) ollamaEl.style.display = useOllama ? 'block' : 'none';
 }
 
 // MCP Config functions


### PR DESCRIPTION
## Summary

- **Agent test end-to-end flow**: Test jobs now use MCP to signal completion, enabling proper end-to-end testing
- **Job executor integration**: Added send_exit parameter to teststatus endpoint for graceful session cleanup
- **Provider config refactor**: Extracted reusable `_provider_config.php` partial for Ollama/Claude settings
- **Pipeline executor**: Updated to use agent's configured provider (Ollama vs Anthropic)
- **SSL verification**: Added verify_ssl config option for localhost development

## Changes

- `controls/Admin.php` - Add sendExitToJobExecutor helper, MCP config for test jobs
- `views/admin/runner_form.php` - Auto-send exit when test completes with 5s delay
- `views/agents/_provider_config.php` - New reusable provider configuration partial
- `services/JobExecutorConfig.php` - Add verify_ssl support
- `services/PipelineExecutor.php` - Use agent's provider config for LLM calls

## Test plan

- [x] Run agent test from runner edit page
- [x] Verify agent responds and calls job_complete via MCP
- [x] Verify session terminates after test completes
- [x] Verify Ollama provider selection works in agent config